### PR TITLE
Improved handling EDNS attributes

### DIFF
--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -85,11 +85,11 @@ func (p *PolicyMiddleware) AddEDNS0Map(code, name, dataType, destType,
 	}
 	offset, err := strconv.Atoi(stringOffset)
 	if err != nil {
-		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
+		return fmt.Errorf("Could not parse EDNS0 string offset: %s", err)
 	}
 	size, err := strconv.Atoi(stringSize)
 	if err != nil {
-		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
+		return fmt.Errorf("Could not parse EDNS0 string size: %s", err)
 	}
 	ednsType, ok := stringToEDNS0MapType[dataType]
 	if !ok {

--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -35,10 +35,12 @@ var stringToEDNS0MapType = map[string]uint16{
 }
 
 type edns0Map struct {
-	code     uint16
-	name     string
-	dataType uint16
-	destType string
+	code         uint16
+	name         string
+	dataType     uint16
+	destType     string
+	stringOffset int
+	stringSize   int
 }
 
 type PolicyMiddleware struct {
@@ -75,8 +77,17 @@ func (p *PolicyMiddleware) Connect() error {
 	return p.pdp.Connect()
 }
 
-func (p *PolicyMiddleware) AddEDNS0Map(code, name, dataType, destType string) error {
+func (p *PolicyMiddleware) AddEDNS0Map(code, name, dataType, destType,
+	stringOffset, stringSize string) error {
 	c, err := strconv.ParseUint(code, 0, 16)
+	if err != nil {
+		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
+	}
+	offset, err := strconv.Atoi(stringOffset)
+	if err != nil {
+		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
+	}
+	size, err := strconv.Atoi(stringSize)
 	if err != nil {
 		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
 	}
@@ -84,7 +95,7 @@ func (p *PolicyMiddleware) AddEDNS0Map(code, name, dataType, destType string) er
 	if !ok {
 		return fmt.Errorf("Invalid dataType for EDNS0 map: %s", dataType)
 	}
-	p.EDNS0Map = append(p.EDNS0Map, edns0Map{uint16(c), name, ednsType, destType})
+	p.EDNS0Map = append(p.EDNS0Map, edns0Map{uint16(c), name, ednsType, destType, offset, size})
 	return nil
 }
 
@@ -97,16 +108,17 @@ func (p *PolicyMiddleware) getEDNS0Attrs(r *dns.Msg) ([]*pb.Attribute, bool) {
 		return nil, false
 	}
 
-	for _, s := range o.Option {
-		switch e := s.(type) {
-		case *dns.EDNS0_NSID:
-			// do stuff with e.Nsid
-		case *dns.EDNS0_SUBNET:
-			// access e.Family, e.Address, etc.
-		case *dns.EDNS0_LOCAL:
-			for _, m := range p.EDNS0Map {
+	for _, m := range p.EDNS0Map {
+		value := ""
+	LOOP:
+		for _, s := range o.Option {
+			switch e := s.(type) {
+			case *dns.EDNS0_NSID:
+				// do stuff with e.Nsid
+			case *dns.EDNS0_SUBNET:
+				// access e.Family, e.Address, etc.
+			case *dns.EDNS0_LOCAL:
 				if m.code == e.Code {
-					var value string
 					switch m.dataType {
 					case EDNS0_MAP_DATA_TYPE_BYTES:
 						value = string(e.Data)
@@ -116,12 +128,17 @@ func (p *PolicyMiddleware) getEDNS0Attrs(r *dns.Msg) ([]*pb.Attribute, bool) {
 						ip := net.IP(e.Data)
 						value = ip.String()
 					}
+					from := m.stringOffset
+					to := m.stringOffset + m.stringSize
+					if to > 0 && to <= len(value) && from < to {
+						value = value[from:to]
+					}
 					foundSourceIP = foundSourceIP || (m.name == "source_ip")
-					attrs = append(attrs, &pb.Attribute{Id: m.name, Type: m.destType, Value: value})
-					break
+					break LOOP
 				}
 			}
 		}
+		attrs = append(attrs, &pb.Attribute{Id: m.name, Type: m.destType, Value: value})
 	}
 	return attrs, foundSourceIP
 }

--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -68,19 +68,29 @@ func policyParse(c *caddy.Controller) (*PolicyMiddleware, error) {
 					return nil, c.ArgErr()
 				case "edns0":
 					args := c.RemainingArgs()
-					if len(args) < 2 || (len(args) != 4 && len(args) != 2) {
-						return nil, fmt.Errorf("Invalid edns0 directive. Usage: edns0 <code> <name> [ <dataType> <destType> ]. Valid dataTypes are hex (default), bytes, ip. Valid destTypes depend on PDP (default string).")
-					}
-					dataType := "hex"
-					destType := "string"
-					if len(args) == 4 {
-						dataType = args[2]
-						destType = args[3]
-					}
-
-					err := mw.AddEDNS0Map(args[0], args[1], dataType, destType)
-					if err != nil {
-						return nil, fmt.Errorf("Could not add EDNS0 map for %s: %s", args[0], err)
+					// Usage: edns0 <code> <name> [ <dataType> <destType> ] [ <stringOffset> <stringSize> ].
+					// Valid dataTypes are hex (default), bytes, ip.
+					// Valid destTypes depend on PDP (default string).
+					argsLen := len(args)
+					if argsLen == 2 || argsLen == 4 || argsLen == 6 {
+						dataType := "hex"
+						destType := "string"
+						stringOffset := "0"
+						stringSize := "0"
+						if argsLen > 2 {
+							dataType = args[2]
+							destType = args[3]
+						}
+						if argsLen == 6 && destType == "string" {
+							stringOffset = args[4]
+							stringSize = args[5]
+						}
+						err := mw.AddEDNS0Map(args[0], args[1], dataType, destType, stringOffset, stringSize)
+						if err != nil {
+							return nil, fmt.Errorf("Could not add EDNS0 map for %s: %s", args[0], err)
+						}
+					} else {
+						return nil, fmt.Errorf("Invalid edns0 directive")
 					}
 				}
 			}


### PR DESCRIPTION
Added additional params for string conversion - stringOffset and stringSize.
Refactor EDNS attributes handling - set empty string ("") if we have attribute in config but don't have it in EDNS.

Example Corefile:
	policy {
		endpoint 127.0.0.1:5555
                # edns0 0xffee client_id
		edns0 0xffee customer_id hex string 0 32 # make customer_id from first 16 bytes of client_id
		# edns0 0xfff1 customer_id
		edns0 0xffef policy_id
		edns0 0xfff2 on_prem_host_id
	}