### PR TITLE
Making PDP server not serving decision requests unless policies will be applied

### DIFF
--- a/pdpserver/main.go
+++ b/pdpserver/main.go
@@ -21,19 +21,6 @@ func main() {
 	pdp.loadContent(conf.content)
 	runtime.GC()
 
-	if pdp.listenRequests(conf.serviceEP) != nil {
-		log.Error("Failed to Listen to Requests.")
-		os.Exit(1)
-	}
-	if pdp.listenControl(conf.controlEP) != nil {
-		log.Error("Failed to Listen to Control Packets.")
-		os.Exit(1)
-	}
-	if pdp.listenHealthCheck(conf.healthEP) != nil {
-		log.Error("Failed to Listen to Health Check.")
-		os.Exit(1)
-	}
-
 	tracer, err := initTracing("zipkin", conf.tracingEP)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Warning("Could not initialize tracing.")


### PR DESCRIPTION
Now PDP server starts to listen the port for decision requests even before it is ready to produce any meaningful answer - when policies are not loaded/applied.

Currently this leads to false negative replies when scaling up PDP servers: CoreDNS tries to query new PDP server which is not ready yet but it allows to establish a connection. And PDP server replies with "There is no any policy to process request" (INDETERMINATE) which is true. Thus CoreDNS returns REFUSE answer to any query.

This PR changes such behaviour of PDP server: it starts to listen on port for decision requests only when there are at least some set of policies (from file or from a PAP server).