### PR TITLE
Improved edns0 options handling

### DIFF
--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestPolicy(t *testing.T) {
-	pm := PolicyPlugin{Next: handler(), options: make(map[uint16]edns0Map)}
+	pm := PolicyPlugin{Next: handler(), options: make(map[uint16][]edns0Map)}
 
 	tests := []struct {
 		query      string
@@ -352,16 +352,25 @@ func makeRequestWithEDNS0(code uint16, hexstring string, nonlocal bool) *dns.Msg
 }
 
 func TestEdns(t *testing.T) {
-	pm := PolicyPlugin{options: make(map[uint16]edns0Map)}
+	pm := PolicyPlugin{options: make(map[uint16][]edns0Map)}
 
 	// Add EDNS mapping
-	if err := pm.AddEDNS0Map("0xfffa", "client_id", "hex", "string", "0", "32"); err != nil {
+	if err := pm.AddEDNS0Map("0xfffa", "client_id", "hex", "string", "0", "16"); err != nil {
+		t.Errorf("Expected error 'nil' but got %v\n", err)
+	}
+	if err := pm.AddEDNS0Map("0xfffa", "group_id", "hex", "string", "16", "32"); err != nil {
 		t.Errorf("Expected error 'nil' but got %v\n", err)
 	}
 	if err := pm.AddEDNS0Map("0xfffb", "source_ip", "address", "address", "0", "0"); err != nil {
 		t.Errorf("Expected error 'nil' but got %v\n", err)
 	}
 	if err := pm.AddEDNS0Map("0xfffc", "client_name", "bytes", "string", "0", "0"); err != nil {
+		t.Errorf("Expected error 'nil' but got %v\n", err)
+	}
+	if err := pm.AddEDNS0Map("0xfffd", "client_uid", "hex", "string", "0", "0"); err != nil {
+		t.Errorf("Expected error 'nil' but got %v\n", err)
+	}
+	if err := pm.AddEDNS0Map("0xfffe", "hex_name", "hex", "string", "2", "0"); err != nil {
 		t.Errorf("Expected error 'nil' but got %v\n", err)
 	}
 
@@ -383,7 +392,7 @@ func TestEdns(t *testing.T) {
 		},
 		{
 			name: "Test option that not in config mapping",
-			code: 0xfffd,
+			code: 0xffff,
 			data: "cafecafe",
 			ip:   "192.168.0.2",
 			attr: map[string]*pdp.Attribute{
@@ -393,11 +402,12 @@ func TestEdns(t *testing.T) {
 		{
 			name: "Test option handled as hex",
 			code: 0xfffa,
-			data: "4e7e318384088e7d4f3dbc96219ee5d4",
+			data: "4e7e318384088e7d4f3dbc96219ee5d4" + "318384088e7d4f3dbc96219ee5d44e7e",
 			ip:   "192.168.0.3",
 			attr: map[string]*pdp.Attribute{
 				"source_ip": {Id: "source_ip", Type: "address", Value: "192.168.0.3"},
 				"client_id": {Id: "client_id", Type: "string", Value: "4e7e318384088e7d4f3dbc96219ee5d4"},
+				"group_id":  {Id: "group_id", Type: "string", Value: "318384088e7d4f3dbc96219ee5d44e7e"},
 			},
 		},
 		{
@@ -418,6 +428,26 @@ func TestEdns(t *testing.T) {
 			attr: map[string]*pdp.Attribute{
 				"source_ip":   {Id: "source_ip", Type: "address", Value: "192.168.0.5"},
 				"client_name": {Id: "client_name", Type: "string", Value: "customer"},
+			},
+		},
+		{
+			name: "Test option handled as hex, start = 0 and end = 0 (whole data)",
+			code: 0xfffd,
+			data: "96219ee5d44e7e318384088e7d4f3dbc",
+			ip:   "192.168.0.6",
+			attr: map[string]*pdp.Attribute{
+				"source_ip":  {Id: "source_ip", Type: "address", Value: "192.168.0.6"},
+				"client_uid": {Id: "client_uid", Type: "string", Value: "96219ee5d44e7e318384088e7d4f3dbc"},
+			},
+		},
+		{
+			name: "Test option handled as hex, start = 2 and end = 0 (from start to end of data)",
+			code: 0xfffe,
+			data: "8e7d" + "4f3dbc96219ee5d44e7e31838408",
+			ip:   "192.168.0.7",
+			attr: map[string]*pdp.Attribute{
+				"source_ip": {Id: "source_ip", Type: "address", Value: "192.168.0.7"},
+				"hex_name":  {Id: "hex_name", Type: "string", Value: "4f3dbc96219ee5d44e7e31838408"},
 			},
 		},
 	}

--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -58,7 +58,7 @@ func setup(c *caddy.Controller) error {
 }
 
 func policyParse(c *caddy.Controller) (*PolicyPlugin, error) {
-	policyPlugin := &PolicyPlugin{options: make(map[uint16]edns0Map)}
+	policyPlugin := &PolicyPlugin{options: make(map[uint16][]edns0Map)}
 
 	for c.Next() {
 		if c.Val() == "policy" {
@@ -74,24 +74,24 @@ func policyParse(c *caddy.Controller) (*PolicyPlugin, error) {
 					return nil, c.ArgErr()
 				case "edns0":
 					args := c.RemainingArgs()
-					// Usage: edns0 <code> <name> [ <dataType> <destType> ] [ <stringOffset> <stringSize> ].
+					// Usage: edns0 <code> <name> [ <dataType> <destType> ] [ <start> <end> ].
 					// Valid dataTypes are hex (default), bytes, ip.
 					// Valid destTypes depend on PDP (default string).
 					argsLen := len(args)
 					if argsLen == 2 || argsLen == 4 || argsLen == 6 {
 						dataType := "hex"
 						destType := "string"
-						stringOffset := "0"
-						stringSize := "0"
+						start := "0"
+						end := "0"
 						if argsLen > 2 {
 							dataType = args[2]
 							destType = args[3]
 						}
-						if argsLen == 6 && destType == "string" {
-							stringOffset = args[4]
-							stringSize = args[5]
+						if argsLen == 6 && dataType == "hex" {
+							start = args[4]
+							end = args[5]
 						}
-						err := policyPlugin.AddEDNS0Map(args[0], args[1], dataType, destType, stringOffset, stringSize)
+						err := policyPlugin.AddEDNS0Map(args[0], args[1], dataType, destType, start, end)
 						if err != nil {
 							return nil, fmt.Errorf("Could not add EDNS0 map for %s: %s", args[0], err)
 						}

--- a/contrib/coredns/policy/setup_test.go
+++ b/contrib/coredns/policy/setup_test.go
@@ -73,7 +73,7 @@ func TestPolicyConfigParse(t *testing.T) {
 						}
 					}`,
 			endpoints:  []string{"10.2.4.1:5555"},
-			errContent: "Could not parse EDNS0 string offset",
+			errContent: "Could not parse EDNS0 start index",
 		},
 		{
 			input: `.:53 {
@@ -83,18 +83,28 @@ func TestPolicyConfigParse(t *testing.T) {
 						}
 					}`,
 			endpoints:  []string{"10.2.4.1:5555"},
-			errContent: "Could not parse EDNS0 string size",
+			errContent: "Could not parse EDNS0 end index",
 		},
 		{
 			input: `.:53 {
 						policy {
 							endpoint 10.2.4.1:5555
-							edns0 0xfff0 uid hex string
-							edns0 0xfff0 id hex string
+							edns0 0xfff0 uid hex string 0 16
+							edns0 0xfff0 id hex string 16 32
 						}
 					}`,
 			endpoints:  []string{"10.2.4.1:5555"},
-			errContent: "Duplicated EDNS0 code",
+			errContent: "",
+		},
+		{
+			input: `.:53 {
+						policy {
+							endpoint 10.2.4.1:5555
+							edns0 0xfff0 uid hex string 16 15
+						}
+					}`,
+			endpoints:  []string{"10.2.4.1:5555"},
+			errContent: "End index should be > start index",
 		},
 		{
 			input: `.:53 {


### PR DESCRIPTION
ATM we have support for splitting any edns0 option to some separate attributes,
syntax:  edns0 [code]  [name] [dataType] [destType] [start] [end]
where [dataType] = hex, [start] is the start index in byte array, [end] is the end index in byte array + 1
Example:
edns0 0xffee customer_id hex string 0 16
edns0 0xffee client_id hex string 16 32
Attributes (data has size 32 bytes - getting from the option with 0xffee code):
customer_id = data[0:16] (first 16 bytes)
client_id = data[16:32] (last 16 bytes)