### PR TITLE
Fixed deadlock on connection recovery

### DIFF
--- a/pep/streaming_connection.go
+++ b/pep/streaming_connection.go
@@ -487,7 +487,7 @@ func (c *streamConn) retryWorker(retry chan boundStream) {
 		if !ok {
 			c.putStream(s)
 			pool.flush()
-			c.crp.put(c)
+			go c.crp.put(c)
 			continue
 		}
 


### PR DESCRIPTION
Prevent disconnection from blocking retry channel reading