### PR TITLE
Refactor sending Dnstap msg from policy plugin

### DIFF
--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -481,6 +481,9 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 		sendExtra bool
 	)
 
+	// turn off default Cq and Cr dnstap messages
+	resetCqCr(ctx)
+
 	debugQuery := p.decodeDebugMsg(r)
 	qName, qType := getNameType(r)
 	for _, s := range p.passthrough {
@@ -547,6 +550,7 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 		status = dns.RcodeNameError
 	case typeRefuse:
 		status = dns.RcodeRefused
+		sendExtra = true
 	default:
 		status = dns.RcodeServerFailure
 		err = errInvalidAction
@@ -562,16 +566,13 @@ Exit:
 		r.Question[0].Qclass = dns.ClassCHAOS
 		sendExtra = false
 	}
-	if p.tapIO != nil && status != dns.RcodeRefused && status != dns.RcodeServerFailure {
-		if pw := newProxyWriter(w); pw != nil {
-			pw.WriteMsg(r)
-			if !sendExtra {
-				ah = nil
-			}
-			p.tapIO.sendCRExtraMsg(pw, ah)
+
+	w.WriteMsg(r)
+	if p.tapIO != nil && status != dns.RcodeServerFailure {
+		if !sendExtra {
+			ah = nil
 		}
-	} else {
-		w.WriteMsg(r)
+		p.tapIO.sendCRExtraMsg(w, r, ah)
 	}
 	return status, err
 }

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -279,6 +279,14 @@ func TestPolicy(t *testing.T) {
 				Obligation: []*pdp.Attribute{{Id: attrNameRefuse, Value: "true"}}},
 			status: dns.RcodeRefused,
 			err:    nil,
+			attrs: []*pdp.Attribute{
+				{Id: attrNameDomainName, Value: "test.org"},
+				{Id: attrNameDNSQtype, Value: "1"},
+				{Id: attrNameSourceIP, Value: "10.240.0.1"},
+				{Id: attrNamePolicyAction, Value: "5"},
+				{Id: attrNameRefuse, Value: "true"},
+				{Id: attrNameType, Value: typeValueQuery},
+			},
 		},
 		{
 			query:     "test.com.",
@@ -288,6 +296,15 @@ func TestPolicy(t *testing.T) {
 				Obligation: []*pdp.Attribute{{Id: attrNameRefuse, Value: "true"}}},
 			status: dns.RcodeRefused,
 			err:    nil,
+			attrs: []*pdp.Attribute{
+				{Id: attrNameDomainName, Value: "test.com"},
+				{Id: attrNameDNSQtype, Value: "1"},
+				{Id: attrNameSourceIP, Value: "10.240.0.1"},
+				{Id: attrNameAddress, Value: "10.240.0.1"},
+				{Id: attrNamePolicyAction, Value: "5"},
+				{Id: attrNameRefuse, Value: "true"},
+				{Id: attrNameType, Value: typeValueResponse},
+			},
 		},
 		{
 			query:     "nxdomain.org.",
@@ -694,7 +711,7 @@ func (s *testDnstapSender) reset() {
 	s.attrs = nil
 }
 
-func (s *testDnstapSender) sendCRExtraMsg(pw *proxyWriter, ah *attrHolder) {
+func (s *testDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder) {
 	if ah != nil {
 		s.attrs = ah.convertAttrs()
 	}

--- a/contrib/coredns/policy/policytap.go
+++ b/contrib/coredns/policy/policytap.go
@@ -5,42 +5,17 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap"
+	tapmsg "github.com/coredns/coredns/plugin/dnstap/msg"
 	"github.com/coredns/coredns/plugin/dnstap/taprw"
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/golang/protobuf/proto"
 	pb "github.com/infobloxopen/themis/contrib/coredns/policy/dnstap"
 	"github.com/miekg/dns"
+	context "golang.org/x/net/context"
 )
 
-// proxyWriter is designed for intercepting a DNS response being writen to
-// ResponseWriter. It also provides access to the base ResponseWriter of type
-// "github.com/coredns/coredns/plugin/dnstap/taprw".ResponseWriter
-type proxyWriter struct {
-	*taprw.ResponseWriter
-	msg *dns.Msg
-}
-
-// newProxyWriter function creates new proxyWriter from a ResponseWriter derived
-// from "github.com/coredns/coredns/plugin/dnstap/taprw".ResponseWriter and
-// turns off sending CQ and CR dnstap messages by dnstap plugin
-// If ResponseWriter is of other type, newProxyWriter returns nil
-func newProxyWriter(w dns.ResponseWriter) *proxyWriter {
-	if tapRW, ok := w.(*taprw.ResponseWriter); ok {
-		// turn off sending the CQ and CR dnstap messages by dnstap plugin
-		tapRW.Send = &taprw.SendOption{}
-		return &proxyWriter{ResponseWriter: tapRW}
-	}
-	return nil
-}
-
-// WriteMsg saves pointer to DNS message and forwards it to base ResponseWriter
-func (w *proxyWriter) WriteMsg(msg *dns.Msg) error {
-	w.msg = msg
-	return w.ResponseWriter.WriteMsg(msg)
-}
-
 type dnstapSender interface {
-	sendCRExtraMsg(pw *proxyWriter, ah *attrHolder)
+	sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder)
 }
 
 type policyDnstapSender struct {
@@ -54,17 +29,16 @@ func newPolicyDnstapSender(io dnstap.IORoutine) dnstapSender {
 // sendCRExtraMsg creates Client Response (CR) dnstap Message and writes an array
 // of extra attributes to Dnstap.Extra field. Then it asynchronously sends the
 // message with IORoutine interface
-// Parameter tapIO must not be nil
-func (s *policyDnstapSender) sendCRExtraMsg(pw *proxyWriter, ah *attrHolder) {
-	if pw == nil || pw.msg == nil {
+func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder) {
+	if w == nil || msg == nil {
 		log.Printf("[ERROR] Failed to create dnstap CR message - no DNS response message found")
 		return
 	}
 	now := time.Now()
-	b := pw.TapBuilder()
+	b := tapmsg.Builder{Full: true}
 	b.TimeSec = uint64(now.Unix())
 	timeNs := uint32(now.Nanosecond())
-	err := b.AddrMsg(pw.RemoteAddr(), pw.msg)
+	err := b.AddrMsg(w.RemoteAddr(), msg)
 	if err != nil {
 		log.Printf("[ERROR] Failed to create dnstap CR message (%v)", err)
 		return
@@ -82,4 +56,13 @@ func (s *policyDnstapSender) sendCRExtraMsg(pw *proxyWriter, ah *attrHolder) {
 	}
 	dnstapMsg := tap.Dnstap{Type: &t, Message: crMsg, Extra: extra}
 	s.ior.Dnstap(dnstapMsg)
+}
+
+func resetCqCr(ctx context.Context) {
+	if v := ctx.Value(dnstap.DnstapSendOption); v != nil {
+		if so, ok := v.(*taprw.SendOption); ok {
+			so.Cq = false
+			so.Cr = false
+		}
+	}
 }


### PR DESCRIPTION
 - Policy plugin doesn't depend on passed ResponseWriter anymore
 - Policy plugin reset CQ and CR flags of dnstap plugin in beginning of
   ServeDNS(). The flags are accessed via context
 - Policy plugin now sends DNSTAP CR msg on REFUSED
 - Removed ProxyWriter
