### PR TITLE
Fixed: No information in logs about category when its added to CF

### DIFF
--- a/pdp/content_test.go
+++ b/pdp/content_test.go
@@ -156,21 +156,21 @@ func TestLocalContentStorage(t *testing.T) {
 	eUpd := fmt.Sprintf("content update: %s - %s\n"+
 		"content: \"first\"\n"+
 		"commands:\n"+
-		"- Add (\"str-str-map\"/\"key\")\n"+
-		"- Add (\"str-net-map\"/\"key\")\n"+
-		"- Add (\"str-dom-map\"/\"key\")\n"+
-		"- Add (\"str-str-map\"/\"key\"/\"4-fourth\")\n"+
-		"- Delete (\"str-str-map\"/\"key\"/\"3-third\")\n"+
-		"- Add (\"str-net-map\"/\"key\"/\"192.0.2.48/28\")\n"+
-		"- Delete (\"str-net-map\"/\"key\"/\"2001:db8::/32\")\n"+
-		"- Add (\"str-dom-map\"/\"key\"/\"example.gov\")\n"+
-		"- Delete (\"str-dom-map\"/\"key\"/\"example.net\")\n"+
-		"- Add (\"str-map\"/\"4-fourth\")\n"+
-		"- Add (\"net-map\"/\"2001:db8:1000::/40\")\n"+
-		"- Add (\"net-map\"/\"2001:db8:1000::1\")\n"+
-		"- Delete (\"str-map\"/\"3-third\")\n"+
-		"- Add (\"dom-map-add\")\n"+
-		"- Delete (\"dom-map-del\")", tag.String(), newTag.String())
+		"- Add path (\"str-str-map\"/\"key\")\n"+
+		"- Add path (\"str-net-map\"/\"key\")\n"+
+		"- Add path (\"str-dom-map\"/\"key\")\n"+
+		"- Add path (\"str-str-map\"/\"key\"/\"4-fourth\")\n"+
+		"- Delete path (\"str-str-map\"/\"key\"/\"3-third\")\n"+
+		"- Add path (\"str-net-map\"/\"key\"/\"192.0.2.48/28\")\n"+
+		"- Delete path (\"str-net-map\"/\"key\"/\"2001:db8::/32\")\n"+
+		"- Add path (\"str-dom-map\"/\"key\"/\"example.gov\")\n"+
+		"- Delete path (\"str-dom-map\"/\"key\"/\"example.net\")\n"+
+		"- Add path (\"str-map\"/\"4-fourth\")\n"+
+		"- Add path (\"net-map\"/\"2001:db8:1000::/40\")\n"+
+		"- Add path (\"net-map\"/\"2001:db8:1000::1\")\n"+
+		"- Delete path (\"str-map\"/\"3-third\")\n"+
+		"- Add path (\"dom-map-add\")\n"+
+		"- Delete path (\"dom-map-del\")", tag.String(), newTag.String())
 	sUpd := u.String()
 	if eUpd != sUpd {
 		t.Errorf("Expected:\n%s\n\nbut got:\n%s\n\n", eUpd, sUpd)

--- a/pdp/context.go
+++ b/pdp/context.go
@@ -270,4 +270,5 @@ type Evaluable interface {
 
 	getOrder() int
 	setOrder(ord int)
+	describe() string
 }

--- a/pdp/policy.go
+++ b/pdp/policy.go
@@ -59,8 +59,16 @@ func NewPolicy(ID string, hidden bool, target Target, rules []*Rule, makeRCA Rul
 }
 
 func (p *Policy) describe() string {
+	ruleIDs := make([]string, len(p.rules))
+	ruleIdx := 0
+	for _, rule := range p.rules {
+		if ruleID, ok := rule.GetID(); ok {
+			ruleIDs[ruleIdx] = ruleID
+			ruleIdx++
+		}
+	}
 	if pid, ok := p.GetID(); ok {
-		return fmt.Sprintf("policy %q", pid)
+		return fmt.Sprintf("policy %q rules(%v)", pid, ruleIDs[:ruleIdx])
 	}
 
 	return "hidden policy"

--- a/pdp/storage.go
+++ b/pdp/storage.go
@@ -143,15 +143,17 @@ func (c *command) describe() string {
 		}
 	}
 
+	opPath := strings.Join(qpath, "/")
 	if nil != c.entity {
 		if evaluable, ok := c.entity.(Evaluable); ok {
-			if id, ok := evaluable.GetID(); ok {
-				qpath = append(qpath, strconv.Quote(id))
-			}
+			// change to something on path
+			return fmt.Sprintf("%s %s to\n  path: (%s)",
+				sop, evaluable.describe(), opPath)
 		}
 	}
 
-	return fmt.Sprintf("%s (%s)", sop, strings.Join(qpath, "/"))
+	// change directly to path
+	return fmt.Sprintf("%s path (%s)", sop, opPath)
 }
 
 // PolicyStorageTransaction represents transaction for policy storage.

--- a/pdp/storage.go
+++ b/pdp/storage.go
@@ -143,6 +143,14 @@ func (c *command) describe() string {
 		}
 	}
 
+	if nil != c.entity {
+		if evaluable, ok := c.entity.(Evaluable); ok {
+			if id, ok := evaluable.GetID(); ok {
+				qpath = append(qpath, strconv.Quote(id))
+			}
+		}
+	}
+
 	return fmt.Sprintf("%s (%s)", sop, strings.Join(qpath, "/"))
 }
 

--- a/pdp/storage_test.go
+++ b/pdp/storage_test.go
@@ -232,8 +232,8 @@ func TestStorageTransactionalUpdate(t *testing.T) {
 
 	eUpd := fmt.Sprintf("policy update: %s - %s\n"+
 		"commands:\n"+
-		"- Add (\"test\"/\"first\")\n"+
-		"- Delete (\"test\"/\"del\")", tag.String(), newTag.String())
+		"- Add path (\"test\"/\"first\")\n"+
+		"- Delete path (\"test\"/\"del\")", tag.String(), newTag.String())
 	sUpd := u.String()
 	if sUpd != eUpd {
 		t.Errorf("Expected:\n%s\n\nupdate but got:\n%s\n\n", eUpd, sUpd)


### PR DESCRIPTION
Change to make logs more informative:
Format from 
```
DEBU[0006]` Policy update                                 update=policy update: 93012340-27cc-47af-97a6-59cd654cf2cc - 7b9096d1-3ad1-4fbf-940d-193d4df780e1
commands:
- Add ("Default"/"query"/"DFPRNetworks"/"0000002e"/"Default")
- Add ("Default"/"query"/"DFPRNetworks"/"CIDRNetworks"/"0000002e"/"Default")
```
to
```
DEBU[0006] Policy update                                 update=policy update: 94db536a-f402-4ea9-a9cb-a3e3445bddf9 - 3664a605-97d3-427d-ac21-4acf8de56f96
commands:
- Add policy "Default" rules([Default News Blogs Tobacco Drugs]) to
  path: ("Default"/"query"/"DFPRNetworks"/"00000001"/"Default")
- Add policy "Default" rules([Default News Blogs Tobacco Drugs]) to
  path: ("Default"/"query"/"DFPRNetworks"/"CIDRNetworks"/"00000001"/"Default")
```