### PR TITLE
Policy plugin: close connection to PDP in OnShutdown() handler

### DIFF
--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -39,12 +39,7 @@ func setup(c *caddy.Controller) error {
 		return nil
 	})
 
-	c.OnRestart(func() error {
-		policyPlugin.closeConn()
-		return nil
-	})
-
-	c.OnFinalShutdown(func() error {
+	c.OnShutdown(func() error {
 		policyPlugin.closeConn()
 		return nil
 	})


### PR DESCRIPTION
 - Closing connection in OnRestart() was incorrect, since OnRestart()
   is called before creation new instance of server, as opposed to
   OnShutdown() handler which is called after creating the new instance