### PR TITLE
Made sure that PDP server shutdowns gracefully on high memory usage

### DIFF
--- a/pdpserver/config.go
+++ b/pdpserver/config.go
@@ -87,7 +87,7 @@ func init() {
 	}
 	conf.policyParser = p
 
-	mem, err := server.MakeMemLimits(*limit*1024*1024, 90, 70, 30, 30)
+	mem, err := server.MakeMemLimits(*limit*1024*1024, 80, 70, 30, 30)
 	if err != nil {
 		log.WithError(err).Fatal("wrong memory limits")
 	}

--- a/pdpserver/server/control.go
+++ b/pdpserver/server/control.go
@@ -136,8 +136,6 @@ func (s *Server) Upload(stream pb.PDPControl_UploadServer) error {
 		}
 	}
 
-	s.checkMemory(s.opts.memLimits)
-
 	return err
 }
 
@@ -161,8 +159,6 @@ func (s *Server) Apply(ctx context.Context, in *pb.Update) (*pb.Response, error)
 	} else {
 		res, err = s.applyContent(in.Id, req)
 	}
-
-	s.checkMemory(s.opts.memLimits)
 
 	return res, err
 }

--- a/pdpserver/server/memory.go
+++ b/pdpserver/server/memory.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"runtime/debug"
 	"runtime/pprof"
 	"time"
 
@@ -70,52 +69,7 @@ func (s *Server) checkMemory(c *MemLimits) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 
-	total := float64(m.HeapSys - m.HeapReleased)
-	limit := float64(c.limit)
-	if total >= 0.85*limit && s.gcPercent > 5 {
-		s.gcPercent = 5
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("Critical memory pressure. Decreasing GC target percentage")
-		debug.SetGCPercent(s.gcPercent)
-	} else if total >= 0.8*limit && s.gcPercent > 10 {
-		s.gcPercent = 10
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("Hard memory pressure. Decreasing GC target percentage")
-		debug.SetGCPercent(s.gcPercent)
-	} else if total >= 0.7*limit && s.gcPercent > 20 {
-		s.gcPercent = 20
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("Moderate memory pressure. Decreasing GC target percentage")
-		debug.SetGCPercent(s.gcPercent)
-	} else if total >= 0.6*limit && s.gcPercent > 30 {
-		s.gcPercent = 30
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("Light memory pressure. Decreasing GC target percentage")
-		debug.SetGCPercent(s.gcPercent)
-	} else if total >= 0.5*limit && s.gcPercent > 50 {
-		s.gcPercent = 50
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("Half of memory in use. Decreasing GC target percentage")
-		debug.SetGCPercent(s.gcPercent)
-	} else if total < 0.3*limit && s.gcPercent != s.gcMax {
-		s.gcPercent = s.gcMax
-		s.opts.logger.WithFields(log.Fields{
-			"allocated": fmtMemSize(m.Sys),
-			"limit":     fmtMemSize(c.limit),
-			"gc%":       s.gcPercent}).Warn("No memory pressure. Returning GC target percentage to maximum")
-		debug.SetGCPercent(s.gcPercent)
-	}
-
+	total := float64(m.Sys - m.HeapReleased)
 	if total >= c.reset {
 		s.opts.logger.WithFields(log.Fields{
 			"allocated": fmtMemSize(m.Sys),
@@ -145,6 +99,7 @@ func (s *Server) checkMemory(c *MemLimits) {
 		s.softMemWarn = nil
 	}
 
+	limit := float64(c.limit)
 	if total > 0.1*limit && float64(m.HeapInuse-m.HeapAlloc)/total >= c.frag {
 		if s.fragMemWarn == nil {
 			tmp := now

--- a/pdpserver/server/server.go
+++ b/pdpserver/server/server.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -156,8 +155,6 @@ type Server struct {
 	softMemWarn *time.Time
 	backMemWarn *time.Time
 	fragMemWarn *time.Time
-	gcMax       int
-	gcPercent   int
 
 	memProfBaseDumpDone chan uint32
 }
@@ -178,14 +175,6 @@ func NewServer(opts ...Option) *Server {
 		o.parser = ast.NewYAMLParser()
 	}
 
-	gcp := debug.SetGCPercent(-1)
-	if gcp != -1 {
-		debug.SetGCPercent(gcp)
-	}
-	if gcp > 50 {
-		gcp = 50
-	}
-
 	var memProfBaseDumpDone chan uint32
 	if o.memProfNumGC > 0 && o.memProfDelay > 0 {
 		memProfBaseDumpDone = make(chan uint32)
@@ -196,8 +185,6 @@ func NewServer(opts ...Option) *Server {
 		errCh:               make(chan error, 100),
 		q:                   newQueue(),
 		c:                   pdp.NewLocalContentStorage(nil),
-		gcMax:               gcp,
-		gcPercent:           gcp,
 		memProfBaseDumpDone: memProfBaseDumpDone,
 	}
 }

--- a/pdpserver/server/server.go
+++ b/pdpserver/server/server.go
@@ -458,6 +458,8 @@ func (s *Server) Serve() error {
 	pbs.RegisterPDPServer(s.requests.proto, s)
 	defer s.requests.proto.Stop()
 
+	go s.memoryChecker()
+
 	if s.p != nil {
 		// We already have policy info applied; supplied from local files,
 		// pointed to by CLI options.


### PR DESCRIPTION
`logger.WithFields(...).Fatal` exits using `os.Exit` which relies on system to close sockets. The change makes memory checker to call explicitly `Stop`.