### PR TITLE
Move flag.Parse() to main()

### DIFF
--- a/pdpserver/main.go
+++ b/pdpserver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	_ "net/http/pprof"
 	"runtime"
 
@@ -10,6 +11,8 @@ import (
 )
 
 func main() {
+	flag.Parse()
+	pdpInitialize()
 	logger := log.StandardLogger()
 	logger.Info("Starting PDP server")
 


### PR DESCRIPTION
Move flag.Parse() to main() so that other packages can use init()
to create flags just like config.go (in this case, ngp-policy-engine/pip/plugin/mcafee)