### PR TITLE
Coredns-plugin: Get User SourceIP when resolving through DNS-Dist

### DIFF
--- a/contrib/coredns/policy/README.md
+++ b/contrib/coredns/policy/README.md
@@ -71,3 +71,7 @@ Dig command example for debug query:
 ~~~ txt
 dig @127.0.0.1 msn.com.debug txt ch
 ~~~
+
+## Alternate Source IP With edns0 Option
+
+Since policies take source IP address, sometimes the true client address is lost on way to coredns (as in the case of proxies). In these cases, the plugin takes the data of builtin edns0 option with code 0xfff5 as the source ip.

--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -482,6 +482,15 @@ func (p *policyPlugin) getAttrsFromEDNS0(ah *attrHolder, r *dns.Msg) {
 		if !local {
 			continue
 		}
+		// hard-coded change on change client ip (0xfff5) flag
+		distFlag, _ := strconv.ParseUint("0xfff5", 0, 16)
+		if optLocal.Code == uint16(distFlag) {
+			if ip := net.IP(optLocal.Data); ip != nil {
+				// change attrNameSourceIP to specified data is valid
+				ah.attrsReqDomain[3].Value = ip.String()
+			}
+			continue
+		}
 		options, ok := p.options[optLocal.Code]
 		if !ok {
 			continue
@@ -603,6 +612,8 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 			goto Exit
 		}
 	}
+
+	// todo: insert remote ip look up here in options (if possible)
 
 	ah = newAttrHolder(qName, qType, getRemoteIP(w), p.transfer)
 	p.getAttrsFromEDNS0(ah, r)

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -694,6 +694,18 @@ func TestEdns(t *testing.T) {
 				attrNameSourceIP:   {Id: attrNameSourceIP, Type: "address", Value: "192.168.0.10"},
 			},
 		},
+		{
+			name: "Test Client from DNS_Dist",
+			code: 0xfff5,
+			data: "0a0a0a0a", // address 10.10.10.10 in test
+			ip:   "192.168.0.4",
+			attr: map[string]*pdp.Attribute{
+				attrNameType:       {Id: attrNameType, Type: "string", Value: "query"},
+				attrNameDNSQtype:   {Id: attrNameDNSQtype, Type: "string", Value: "1"},
+				attrNameDomainName: {Id: attrNameDomainName, Type: "domain", Value: "test.com"},
+				attrNameSourceIP:   {Id: attrNameSourceIP, Type: "address", Value: "10.10.10.10"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I'm making this change to solve issues dealing with the following use case:

- Use 1: User (addr X) calls Coredns directly to resolve their query. In this scenario, the SourceIP takes address X. (Expected behavior)
- Use 2: User (addr X) calls Coredns through DNS-Dist (addr Y). In this scenario, the SourceIP takes address Y. (Unexpected behavior)

We want both use cases to have SourceIP take X (user IP).
Since the source IP is lost along the way to DNS-Dist, Thong proposed passing the user's IP as an edns0 option with code 0xfff5.
These changes allows Coredns-plugin to read this option.