### PR TITLE
Make selector interface

### DIFF
--- a/pdp/selector.go
+++ b/pdp/selector.go
@@ -4,11 +4,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type SelectorFunc func(string, []Expression, int) (Expression, error)
+type Selector interface {
+	Enabled() bool
+	SelectorFunc(string, []Expression, int) (Expression, error)
+}
 
-var SelectorMap = map[string]SelectorFunc{}
+var SelectorMap = make(map[string]Selector)
 
-func RegisterSelector(name string, fn SelectorFunc) {
+func RegisterSelector(name string, s Selector) {
 	log.Debugf("Register %s selector", name)
-	SelectorMap[name] = fn
+	SelectorMap[name] = s
 }

--- a/pdp/selector.go
+++ b/pdp/selector.go
@@ -6,6 +6,7 @@ import (
 
 type Selector interface {
 	Enabled() bool
+	Initialize()
 	SelectorFunc(string, []Expression, int) (Expression, error)
 }
 
@@ -14,4 +15,12 @@ var SelectorMap = make(map[string]Selector)
 func RegisterSelector(name string, s Selector) {
 	log.Debugf("Register %s selector", name)
 	SelectorMap[name] = s
+}
+
+func InitializeSelectors() {
+	for _, e := range SelectorMap {
+		if e.Enabled() {
+			e.Initialize()
+		}
+	}
 }

--- a/pdp/selector/local/init.go
+++ b/pdp/selector/local/init.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	pdp.RegisterSelector("local", &Selector{})
+	pdp.RegisterSelector("local", &selector{})
 }

--- a/pdp/selector/local/init.go
+++ b/pdp/selector/local/init.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	pdp.RegisterSelector("local", MakeLocalSelector)
+	pdp.RegisterSelector("local", &Selector{})
 }

--- a/pdp/selector/local/local_selector.go
+++ b/pdp/selector/local/local_selector.go
@@ -7,6 +7,16 @@ import (
 	"github.com/infobloxopen/themis/pdp"
 )
 
+type Selector struct{}
+
+func (s *Selector) Enabled() bool {
+	return true
+}
+
+func (s *Selector) SelectorFunc(uri string, path []pdp.Expression, t int) (pdp.Expression, error) {
+	return MakeLocalSelector(uri, path, t)
+}
+
 // LocalSelector represent local selector expression. The expression extracts
 // value from local content storage by given path and validates that result
 // has desired type.

--- a/pdp/selector/local/local_selector.go
+++ b/pdp/selector/local/local_selector.go
@@ -7,15 +7,17 @@ import (
 	"github.com/infobloxopen/themis/pdp"
 )
 
-type Selector struct{}
+type selector struct{}
 
-func (s *Selector) Enabled() bool {
+func (s *selector) Enabled() bool {
 	return true
 }
 
-func (s *Selector) SelectorFunc(uri string, path []pdp.Expression, t int) (pdp.Expression, error) {
+func (s *selector) SelectorFunc(uri string, path []pdp.Expression, t int) (pdp.Expression, error) {
 	return MakeLocalSelector(uri, path, t)
 }
+
+func (s *selector) Initialize() {}
 
 // LocalSelector represent local selector expression. The expression extracts
 // value from local content storage by given path and validates that result

--- a/pdp/selector/selector.go
+++ b/pdp/selector/selector.go
@@ -9,9 +9,12 @@ import (
 // MakeSelector returns new selector with given parameters
 func MakeSelector(proto string, uri string, path []pdp.Expression, t int) (pdp.Expression, error) {
 	var ret pdp.Expression
-	selectorFunc, ok := pdp.SelectorMap[proto]
+	selector, ok := pdp.SelectorMap[proto]
 	if !ok {
-		return ret, fmt.Errorf("Unsupported selector scheme %s", proto)
+		return ret, fmt.Errorf("unsupported selector scheme %s", proto)
 	}
-	return selectorFunc(uri, path, t)
+	if !selector.Enabled() {
+		return ret, fmt.Errorf("selector scheme %s is not enabled", proto)
+	}
+	return selector.SelectorFunc(uri, path, t)
 }

--- a/pdpserver/main.go
+++ b/pdpserver/main.go
@@ -34,6 +34,8 @@ func main() {
 		),
 	)
 
+	pdp.InitializeSelectors()
+
 	err := pdp.LoadPolicies(conf.policy)
 	if err != nil {
 		logger.WithFields(

--- a/pdpserver/server/server.go
+++ b/pdpserver/server/server.go
@@ -264,6 +264,11 @@ func (s *Server) LoadContent(paths []string) error {
 	return nil
 }
 
+// InitializeSelectors initialize all registered selectors that are enabled
+func (s *Server) InitializeSelectors() {
+	pdp.InitializeSelectors()
+}
+
 // ReadContent reads content with using io.Reader instances
 func (s *Server) ReadContent(readers ...io.Reader) error {
 	items := []*pdp.LocalContent{}


### PR DESCRIPTION
Instead of registering a SelectorFunc, register object that implements a Selector interface which includes the following methods:
1) Enabled() - whether the selector is enabled
2) Initialize() - initialize the selector
3) SelectorFunc() - create the selector expression.