### PR TITLE
pdpctrl-client upload check io.EOF error for on Send

### DIFF
--- a/pdpctrl-client/client.go
+++ b/pdpctrl-client/client.go
@@ -119,7 +119,7 @@ func (c *Client) Upload(id int32, r io.Reader) (int32, error) {
 			chunk := &pb.Chunk{
 				Id:   id,
 				Data: string(p[:n])}
-			if err := u.Send(chunk); err != nil {
+			if err := u.Send(chunk); err != nil && err != io.EOF {
 				return -1, err
 			}
 		}


### PR DESCRIPTION
Even though send returning io.EOF error is problematic, we should send all chunks to get more informative error from PDP server