### PR TITLE
Marshal Targets, Obligations, and Algorithms

### DIFF
--- a/pdp/flags_mapper_pca.go
+++ b/pdp/flags_mapper_pca.go
@@ -63,8 +63,13 @@ func (a flagsMapperPCA) execute(policies []Evaluable, ctx *Context) Response {
 }
 
 func (a flagsMapperPCA) MarshalJSON() ([]byte, error) {
-	defID, _ := a.def.GetID()
-	errID, _ := a.err.GetID()
+	var defID, errID string
+	if a.def != nil {
+		defID, _ = a.def.GetID()
+	}
+	if a.err != nil {
+		errID, _ = a.err.GetID()
+	}
 	return json.Marshal(mapperAlgFmt{
 		Type:      "flagsMapperPCA",
 		Default:   strconv.Quote(defID),

--- a/pdp/flags_mapper_pca.go
+++ b/pdp/flags_mapper_pca.go
@@ -1,6 +1,10 @@
 package pdp
 
-import "sort"
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+)
 
 type flagsMapperPCA struct {
 	argument  Expression
@@ -56,6 +60,17 @@ func (a flagsMapperPCA) execute(policies []Evaluable, ctx *Context) Response {
 	}
 
 	return a.calculateErrorPolicy(ctx, newFlagsMapperRCAArgumentTypeError(t))
+}
+
+func (a flagsMapperPCA) MarshalJSON() ([]byte, error) {
+	defID, _ := a.def.GetID()
+	errID, _ := a.err.GetID()
+	return json.Marshal(mapperAlgFmt{
+		Type:      "flagsMapperPCA",
+		Default:   strconv.Quote(defID),
+		Error:     strconv.Quote(errID),
+		Algorithm: a.algorithm,
+	})
 }
 
 func (a flagsMapperPCA) add(ID string, child, old Evaluable) PolicyCombiningAlg {

--- a/pdp/flags_mapper_pca_test.go
+++ b/pdp/flags_mapper_pca_test.go
@@ -1,6 +1,9 @@
 package pdp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestFlagsMapperPCAOrdering(t *testing.T) {
 	ft, err := NewFlagsType("flags", "third", "first", "second")
@@ -92,5 +95,60 @@ func TestFlagsMapperPCAOrdering(t *testing.T) {
 		if ID != eID || ot != eot.GetKey() || s != es {
 			t.Errorf("Expected %q = %q.(%s) obligation but got %q = %q.(%s)", eID, es, eot, ID, s, ot)
 		}
+	}
+}
+
+const (
+	expectEmptyFlagMapperPCAJSON = `{"type":"flagsMapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
+	expectFlagMapperPCAJSON      = `{"type":"flagsMapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
+)
+
+func TestFlagsMapperPCAMarshal(t *testing.T) {
+	ft, err := NewFlagsType("flags", "third", "first", "second")
+	if err != nil {
+		t.Fatalf("Expected no error but got: %s", err)
+	}
+	policies := []Evaluable{
+		makeSimplePermitPolicyWithObligations(
+			"first",
+			makeSingleStringObligation("order", "first"),
+		),
+		makeSimplePermitPolicyWithObligations(
+			"second",
+			makeSingleStringObligation("order", "second"),
+		),
+		makeSimplePermitPolicyWithObligations(
+			"third",
+			makeSingleStringObligation("order", "third"),
+		),
+	}
+	algParam := MapperPCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "f", t: ft}},
+		Order:     MapperPCAInternalOrder,
+		Algorithm: firstApplicableEffectPCA{},
+	}
+	alg := makeMapperPCA(policies, algParam)
+	b, err := json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectEmptyFlagMapperPCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyFlagMapperPCAJSON, string(b))
+	}
+
+	algParam2 := MapperPCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "f", t: ft}},
+		Order:     MapperPCAInternalOrder,
+		Algorithm: firstApplicableEffectPCA{},
+		Def:       "first",
+		DefOk:     true,
+		Err:       "second",
+		ErrOk:     true,
+	}
+	alg = makeMapperPCA(policies, algParam2)
+	b, err = json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectFlagMapperPCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectFlagMapperPCAJSON, string(b))
 	}
 }

--- a/pdp/flags_mapper_pca_test.go
+++ b/pdp/flags_mapper_pca_test.go
@@ -98,12 +98,12 @@ func TestFlagsMapperPCAOrdering(t *testing.T) {
 	}
 }
 
-const (
-	expectEmptyFlagMapperPCAJSON = `{"type":"flagsMapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
-	expectFlagMapperPCAJSON      = `{"type":"flagsMapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
-)
-
 func TestFlagsMapperPCAMarshal(t *testing.T) {
+	const (
+		expectEmptyFlagMapperPCAJSON = `{"type":"flagsMapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
+		expectFlagMapperPCAJSON      = `{"type":"flagsMapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
+	)
+
 	ft, err := NewFlagsType("flags", "third", "first", "second")
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
@@ -128,10 +128,8 @@ func TestFlagsMapperPCAMarshal(t *testing.T) {
 		Algorithm: firstApplicableEffectPCA{},
 	}
 	alg := makeMapperPCA(policies, algParam)
-	b, err := json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectEmptyFlagMapperPCAJSON != string(b) {
+	b, _ := json.Marshal(alg)
+	if expectEmptyFlagMapperPCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyFlagMapperPCAJSON, string(b))
 	}
 
@@ -145,10 +143,8 @@ func TestFlagsMapperPCAMarshal(t *testing.T) {
 		ErrOk:     true,
 	}
 	alg = makeMapperPCA(policies, algParam2)
-	b, err = json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectFlagMapperPCAJSON != string(b) {
+	b, _ = json.Marshal(alg)
+	if expectFlagMapperPCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectFlagMapperPCAJSON, string(b))
 	}
 }

--- a/pdp/flags_mapper_rca.go
+++ b/pdp/flags_mapper_rca.go
@@ -1,7 +1,9 @@
 package pdp
 
 import (
+	"encoding/json"
 	"sort"
+	"strconv"
 )
 
 type flagsMapperRCA struct {
@@ -58,6 +60,15 @@ func (a flagsMapperRCA) execute(rules []*Rule, ctx *Context) Response {
 	}
 
 	return a.calculateErrorRule(ctx, newFlagsMapperRCAArgumentTypeError(t))
+}
+
+func (a flagsMapperRCA) MarshalJSON() ([]byte, error) {
+	return json.Marshal(mapperAlgFmt{
+		Type:      "flagsMapperRCA",
+		Default:   strconv.Quote(a.def.id),
+		Error:     strconv.Quote(a.err.id),
+		Algorithm: a.algorithm,
+	})
 }
 
 func (a flagsMapperRCA) add(ID string, child, old *Rule) RuleCombiningAlg {

--- a/pdp/flags_mapper_rca.go
+++ b/pdp/flags_mapper_rca.go
@@ -63,10 +63,17 @@ func (a flagsMapperRCA) execute(rules []*Rule, ctx *Context) Response {
 }
 
 func (a flagsMapperRCA) MarshalJSON() ([]byte, error) {
+	var defID, errID string
+	if a.def != nil {
+		defID = a.def.id
+	}
+	if a.err != nil {
+		errID = a.err.id
+	}
 	return json.Marshal(mapperAlgFmt{
 		Type:      "flagsMapperRCA",
-		Default:   strconv.Quote(a.def.id),
-		Error:     strconv.Quote(a.err.id),
+		Default:   strconv.Quote(defID),
+		Error:     strconv.Quote(errID),
 		Algorithm: a.algorithm,
 	})
 }

--- a/pdp/flags_mapper_rca_test.go
+++ b/pdp/flags_mapper_rca_test.go
@@ -98,12 +98,12 @@ func TestFlagsMapperRCAOrdering(t *testing.T) {
 	}
 }
 
-const (
-	expectEmptyFlagMapperRCAJSON = `{"type":"flagsMapperRCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectRCA"}}`
-	expectFlagMapperRCAJSON      = `{"type":"flagsMapperRCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectRCA"}}`
-)
-
 func TestFlagsMapperRCAMarshal(t *testing.T) {
+	const (
+		expectEmptyFlagMapperRCAJSON = `{"type":"flagsMapperRCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectRCA"}}`
+		expectFlagMapperRCAJSON      = `{"type":"flagsMapperRCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectRCA"}}`
+	)
+
 	ft, err := NewFlagsType("flags", "third", "first", "second")
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
@@ -128,10 +128,8 @@ func TestFlagsMapperRCAMarshal(t *testing.T) {
 		Algorithm: firstApplicableEffectRCA{},
 	}
 	alg := makeMapperRCA(rules, algParam)
-	b, err := json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectEmptyFlagMapperRCAJSON != string(b) {
+	b, _ := json.Marshal(alg)
+	if expectEmptyFlagMapperRCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyFlagMapperRCAJSON, string(b))
 	}
 
@@ -145,10 +143,8 @@ func TestFlagsMapperRCAMarshal(t *testing.T) {
 		ErrOk:     true,
 	}
 	alg = makeMapperRCA(rules, algParam2)
-	b, err = json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectFlagMapperRCAJSON != string(b) {
+	b, _ = json.Marshal(alg)
+	if expectFlagMapperRCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectFlagMapperRCAJSON, string(b))
 	}
 }

--- a/pdp/mapper_pca.go
+++ b/pdp/mapper_pca.go
@@ -180,8 +180,13 @@ func makeMapperPCA(policies []Evaluable, params interface{}) PolicyCombiningAlg 
 }
 
 func (a mapperPCA) MarshalJSON() ([]byte, error) {
-	defID, _ := a.def.GetID()
-	errID, _ := a.err.GetID()
+	var defID, errID string
+	if a.def != nil {
+		defID, _ = a.def.GetID()
+	}
+	if a.err != nil {
+		errID, _ = a.err.GetID()
+	}
 	return json.Marshal(mapperAlgFmt{
 		Type:      "mapperPCA",
 		Default:   strconv.Quote(defID),

--- a/pdp/mapper_pca.go
+++ b/pdp/mapper_pca.go
@@ -1,8 +1,10 @@
 package pdp
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/infobloxopen/go-trees/strtree"
@@ -175,6 +177,17 @@ func makeMapperPCA(policies []Evaluable, params interface{}) PolicyCombiningAlg 
 		err:       err,
 		order:     mapperParams.Order,
 		algorithm: mapperParams.Algorithm}
+}
+
+func (a mapperPCA) MarshalJSON() ([]byte, error) {
+	defID, _ := a.def.GetID()
+	errID, _ := a.err.GetID()
+	return json.Marshal(mapperAlgFmt{
+		Type:      "mapperPCA",
+		Default:   strconv.Quote(defID),
+		Error:     strconv.Quote(errID),
+		Algorithm: a.algorithm,
+	})
 }
 
 func (a mapperPCA) describe() string {

--- a/pdp/mapper_pca_test.go
+++ b/pdp/mapper_pca_test.go
@@ -101,12 +101,12 @@ func TestMapperPCAOrdering(t *testing.T) {
 	}
 }
 
-const (
-	expectEmptyMapperPCAJSON = `{"type":"mapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
-	expectMapperPCAJSON      = `{"type":"mapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
-)
-
 func TestMapperPCAMarshal(t *testing.T) {
+	const (
+		expectEmptyMapperPCAJSON = `{"type":"mapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
+		expectMapperPCAJSON      = `{"type":"mapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
+	)
+
 	policies := []Evaluable{
 		makeSimplePermitPolicyWithObligations(
 			"first",
@@ -127,10 +127,8 @@ func TestMapperPCAMarshal(t *testing.T) {
 		Algorithm: firstApplicableEffectPCA{},
 	}
 	alg := makeMapperPCA(policies, algParam)
-	b, err := json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectEmptyMapperPCAJSON != string(b) {
+	b, _ := json.Marshal(alg)
+	if expectEmptyMapperPCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyMapperPCAJSON, string(b))
 	}
 
@@ -144,10 +142,8 @@ func TestMapperPCAMarshal(t *testing.T) {
 		ErrOk:     true,
 	}
 	alg = makeMapperPCA(policies, algParam2)
-	b, err = json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectMapperPCAJSON != string(b) {
+	b, _ = json.Marshal(alg)
+	if expectMapperPCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectMapperPCAJSON, string(b))
 	}
 }

--- a/pdp/mapper_pca_test.go
+++ b/pdp/mapper_pca_test.go
@@ -1,6 +1,9 @@
 package pdp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestMapperPCAOrders(t *testing.T) {
 	if totalMapperPCAOrders != len(MapperPCAOrderNames) {
@@ -95,5 +98,56 @@ func TestMapperPCAOrdering(t *testing.T) {
 		if ID != eID || ot != eot.GetKey() || s != es {
 			t.Errorf("Expected %q = %q.(%s) obligation but got %q = %q.(%s)", eID, es, eot, ID, s, ot)
 		}
+	}
+}
+
+const (
+	expectEmptyMapperPCAJSON = `{"type":"mapperPCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectPCA"}}`
+	expectMapperPCAJSON      = `{"type":"mapperPCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectPCA"}}`
+)
+
+func TestMapperPCAMarshal(t *testing.T) {
+	policies := []Evaluable{
+		makeSimplePermitPolicyWithObligations(
+			"first",
+			makeSingleStringObligation("order", "first"),
+		),
+		makeSimplePermitPolicyWithObligations(
+			"second",
+			makeSingleStringObligation("order", "second"),
+		),
+		makeSimplePermitPolicyWithObligations(
+			"third",
+			makeSingleStringObligation("order", "third"),
+		),
+	}
+	algParam := MapperPCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "k", t: TypeListOfStrings}},
+		Order:     MapperPCAExternalOrder,
+		Algorithm: firstApplicableEffectPCA{},
+	}
+	alg := makeMapperPCA(policies, algParam)
+	b, err := json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectEmptyMapperPCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyMapperPCAJSON, string(b))
+	}
+
+	algParam2 := MapperPCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "k", t: TypeListOfStrings}},
+		Order:     MapperPCAExternalOrder,
+		Algorithm: firstApplicableEffectPCA{},
+		Def:       "first",
+		DefOk:     true,
+		Err:       "second",
+		ErrOk:     true,
+	}
+	alg = makeMapperPCA(policies, algParam2)
+	b, err = json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectMapperPCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectMapperPCAJSON, string(b))
 	}
 }

--- a/pdp/mapper_rca.go
+++ b/pdp/mapper_rca.go
@@ -211,10 +211,17 @@ func makeMapperRCA(rules []*Rule, params interface{}) RuleCombiningAlg {
 }
 
 func (a mapperRCA) MarshalJSON() ([]byte, error) {
+	var defID, errID string
+	if a.def != nil {
+		defID = a.def.id
+	}
+	if a.err != nil {
+		errID = a.err.id
+	}
 	return json.Marshal(mapperAlgFmt{
 		Type:      "mapperRCA",
-		Default:   strconv.Quote(a.def.id),
-		Error:     strconv.Quote(a.err.id),
+		Default:   strconv.Quote(defID),
+		Error:     strconv.Quote(errID),
 		Algorithm: a.algorithm,
 	})
 }

--- a/pdp/mapper_rca.go
+++ b/pdp/mapper_rca.go
@@ -1,8 +1,10 @@
 package pdp
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/infobloxopen/go-trees/strtree"
@@ -206,6 +208,15 @@ func makeMapperRCA(rules []*Rule, params interface{}) RuleCombiningAlg {
 		order:     mapperParams.Order,
 		algorithm: mapperParams.Algorithm,
 	}
+}
+
+func (a mapperRCA) MarshalJSON() ([]byte, error) {
+	return json.Marshal(mapperAlgFmt{
+		Type:      "mapperRCA",
+		Default:   strconv.Quote(a.def.id),
+		Error:     strconv.Quote(a.err.id),
+		Algorithm: a.algorithm,
+	})
 }
 
 func (a mapperRCA) describe() string {

--- a/pdp/mapper_rca_test.go
+++ b/pdp/mapper_rca_test.go
@@ -1,6 +1,9 @@
 package pdp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestMapperRCAOrders(t *testing.T) {
 	if totalMapperRCAOrders != len(MapperRCAOrderNames) {
@@ -95,5 +98,56 @@ func TestMapperRCAOrdering(t *testing.T) {
 		if ID != eID || ot != eot.GetKey() || s != es {
 			t.Errorf("Expected %q = %q.(%s) obligation but got %q = %q.(%s)", eID, es, eot, ID, s, ot)
 		}
+	}
+}
+
+const (
+	expectEmptyMapperRCAJSON = `{"type":"mapperRCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectRCA"}}`
+	expectMapperRCAJSON      = `{"type":"mapperRCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectRCA"}}`
+)
+
+func TestMapperRCAMarshal(t *testing.T) {
+	rules := []*Rule{
+		makeSimplePermitRuleWithObligations(
+			"first",
+			makeSingleStringObligation("order", "first"),
+		),
+		makeSimplePermitRuleWithObligations(
+			"second",
+			makeSingleStringObligation("order", "second"),
+		),
+		makeSimplePermitRuleWithObligations(
+			"third",
+			makeSingleStringObligation("order", "third"),
+		),
+	}
+	algParam := MapperRCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "k", t: TypeListOfStrings}},
+		Order:     MapperRCAExternalOrder,
+		Algorithm: firstApplicableEffectRCA{},
+	}
+	alg := makeMapperRCA(rules, algParam)
+	b, err := json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectEmptyMapperRCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyMapperRCAJSON, string(b))
+	}
+
+	algParam2 := MapperRCAParams{
+		Argument:  AttributeDesignator{a: Attribute{id: "k", t: TypeListOfStrings}},
+		Order:     MapperRCAExternalOrder,
+		Algorithm: firstApplicableEffectRCA{},
+		Def:       "first",
+		DefOk:     true,
+		Err:       "second",
+		ErrOk:     true,
+	}
+	alg = makeMapperRCA(rules, algParam2)
+	b, err = json.Marshal(alg)
+	if err != nil {
+		t.Fatalf("Expected no marshaling error but got: %s", err)
+	} else if expectMapperRCAJSON != string(b) {
+		t.Errorf("Expected marshalled %s\nGot %s", expectMapperRCAJSON, string(b))
 	}
 }

--- a/pdp/mapper_rca_test.go
+++ b/pdp/mapper_rca_test.go
@@ -101,12 +101,12 @@ func TestMapperRCAOrdering(t *testing.T) {
 	}
 }
 
-const (
-	expectEmptyMapperRCAJSON = `{"type":"mapperRCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectRCA"}}`
-	expectMapperRCAJSON      = `{"type":"mapperRCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectRCA"}}`
-)
-
 func TestMapperRCAMarshal(t *testing.T) {
+	const (
+		expectEmptyMapperRCAJSON = `{"type":"mapperRCA","def":"\"\"","err":"\"\"","alg":{"type":"firstApplicableEffectRCA"}}`
+		expectMapperRCAJSON      = `{"type":"mapperRCA","def":"\"first\"","err":"\"second\"","alg":{"type":"firstApplicableEffectRCA"}}`
+	)
+
 	rules := []*Rule{
 		makeSimplePermitRuleWithObligations(
 			"first",
@@ -127,10 +127,8 @@ func TestMapperRCAMarshal(t *testing.T) {
 		Algorithm: firstApplicableEffectRCA{},
 	}
 	alg := makeMapperRCA(rules, algParam)
-	b, err := json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectEmptyMapperRCAJSON != string(b) {
+	b, _ := json.Marshal(alg)
+	if expectEmptyMapperRCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectEmptyMapperRCAJSON, string(b))
 	}
 
@@ -144,10 +142,8 @@ func TestMapperRCAMarshal(t *testing.T) {
 		ErrOk:     true,
 	}
 	alg = makeMapperRCA(rules, algParam2)
-	b, err = json.Marshal(alg)
-	if err != nil {
-		t.Fatalf("Expected no marshaling error but got: %s", err)
-	} else if expectMapperRCAJSON != string(b) {
+	b, _ = json.Marshal(alg)
+	if expectMapperRCAJSON != string(b) {
 		t.Errorf("Expected marshalled %s\nGot %s", expectMapperRCAJSON, string(b))
 	}
 }

--- a/pdp/marshal.go
+++ b/pdp/marshal.go
@@ -14,20 +14,20 @@ type StorageMarshal interface {
 
 // PolicySet/Policy representation for marshaling
 type storageEvalFmt struct {
-	Ord         int                             `json:"ord"`
-	ID          string                          `json:"id"`
-	Target      Target                          `json:"target"`
-	Obligations []AttributeAssignmentExpression `json:"obligations"`
-	Algorithm   json.Marshaler                  `json:"algorithm"`
+	Ord         int                   `json:"ord"`
+	ID          string                `json:"id"`
+	Target      Target                `json:"target"`
+	Obligations []AttributeAssignment `json:"obligations"`
+	Algorithm   json.Marshaler        `json:"algorithm"`
 }
 
 // Rule representation for marshaling
 type storageRuleFmt struct {
-	Ord         int                             `json:"ord"`
-	ID          string                          `json:"id"`
-	Target      Target                          `json:"target"`
-	Obligations []AttributeAssignmentExpression `json:"obligations"`
-	Effect      string                          `json:"effect"`
+	Ord         int                   `json:"ord"`
+	ID          string                `json:"id"`
+	Target      Target                `json:"target"`
+	Obligations []AttributeAssignment `json:"obligations"`
+	Effect      string                `json:"effect"`
 }
 
 func marshalHeader(v interface{}, out io.Writer) error {

--- a/pdp/marshal.go
+++ b/pdp/marshal.go
@@ -12,10 +12,21 @@ type StorageMarshal interface {
 	MarshalWithDepth(out io.Writer, depth int) error
 }
 
-// PolicySet/Policy/Rule representation for marshaling
-type storageNodeFmt struct {
-	Ord int    `json:"ord"`
-	ID  string `json:"id"`
+// PolicySet/Policy representation for marshaling
+type storageEvalFmt struct {
+	Ord         int                             `json:"ord"`
+	ID          string                          `json:"id"`
+	Target      Target                          `json:"target"`
+	Obligations []AttributeAssignmentExpression `json:"obligations"`
+	Algorithm   json.Marshaler                  `json:"algorithm"`
+}
+
+// Rule representation for marshaling
+type storageRuleFmt struct {
+	Ord         int                             `json:"ord"`
+	ID          string                          `json:"id"`
+	Target      Target                          `json:"target"`
+	Obligations []AttributeAssignmentExpression `json:"obligations"`
 }
 
 func marshalHeader(v interface{}, out io.Writer) error {
@@ -29,4 +40,16 @@ func marshalHeader(v interface{}, out io.Writer) error {
 	}
 	_, err = out.Write(b[:n-1])
 	return err
+}
+
+// Algorithm representation for marshalling
+type algFmt struct {
+	Type string `json:"type"`
+}
+
+type mapperAlgFmt struct {
+	Type      string         `json:"type"`
+	Default   string         `json:"def"`
+	Error     string         `json:"err"`
+	Algorithm json.Marshaler `json:"alg"`
 }

--- a/pdp/marshal.go
+++ b/pdp/marshal.go
@@ -27,6 +27,7 @@ type storageRuleFmt struct {
 	ID          string                          `json:"id"`
 	Target      Target                          `json:"target"`
 	Obligations []AttributeAssignmentExpression `json:"obligations"`
+	Effect      string                          `json:"effect"`
 }
 
 func marshalHeader(v interface{}, out io.Writer) error {

--- a/pdp/policy_set_test.go
+++ b/pdp/policy_set_test.go
@@ -954,7 +954,7 @@ func TestPolicySetMarshalWithDepth(t *testing.T) {
 
 	// show children, visible policy
 	policyExtra := `"target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectRCA"}`
-	cRule := `,"rules":[{"ord":0,"id":"permit","target":{},"obligations":null}]}`
+	cRule := `,"rules":[{"ord":0,"id":"permit","target":{},"obligations":null,"effect":"Permit"}]}`
 	expectChildren := `{"ord":0,"id":"first",` + policyExtra + cRule +
 		`,{"ord":1,"id":"second",` + policyExtra + cRule +
 		`,{"ord":2,"id":"third",` + policyExtra + cRule

--- a/pdp/policy_set_test.go
+++ b/pdp/policy_set_test.go
@@ -940,7 +940,8 @@ func TestPolicySetMarshalWithDepth(t *testing.T) {
 	}
 
 	// depth = 0, visible policy
-	expectMarshal := `{"ord":0,"id":"test","policies":[]}`
+	policySetExtra := `"target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectPCA"},`
+	expectMarshal := `{"ord":0,"id":"test",` + policySetExtra + `"policies":[]}`
 	err = p.MarshalWithDepth(&buf, 0)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)
@@ -952,9 +953,12 @@ func TestPolicySetMarshalWithDepth(t *testing.T) {
 	}
 
 	// show children, visible policy
-	cRule := `,"rules":[{"ord":0,"id":"permit"}]}`
-	expectChildren := `{"ord":0,"id":"first"` + cRule + `,{"ord":1,"id":"second"` + cRule + `,{"ord":2,"id":"third"` + cRule
-	expectWithC := `{"ord":0,"id":"test","policies":[` + expectChildren + `]}`
+	policyExtra := `"target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectRCA"}`
+	cRule := `,"rules":[{"ord":0,"id":"permit","target":{},"obligations":null}]}`
+	expectChildren := `{"ord":0,"id":"first",` + policyExtra + cRule +
+		`,{"ord":1,"id":"second",` + policyExtra + cRule +
+		`,{"ord":2,"id":"third",` + policyExtra + cRule
+	expectWithC := `{"ord":0,"id":"test",` + policySetExtra + `"policies":[` + expectChildren + `]}`
 	err = p.MarshalWithDepth(&buf2, 2)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)

--- a/pdp/policy_test.go
+++ b/pdp/policy_test.go
@@ -776,7 +776,8 @@ func TestPolicyMarshalWithDepth(t *testing.T) {
 	}
 
 	// show children, visible policy
-	expectChildren := `{"ord":0,"id":"first","target":{},"obligations":null},{"ord":1,"id":"second","target":{},"obligations":null},{"ord":2,"id":"third","target":{},"obligations":null}`
+	expectChild := `{"ord":%d,"id":"%s","target":{},"obligations":null,"effect":"Permit"}`
+	expectChildren := fmt.Sprintf(expectChild, 0, "first") + "," + fmt.Sprintf(expectChild, 1, "second") + "," + fmt.Sprintf(expectChild, 2, "third")
 	expectWithC := `{"ord":0,"id":"test","target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectRCA"},"rules":[` + expectChildren + `]}`
 	err = p.MarshalWithDepth(&buf2, 1)
 	if err != nil {

--- a/pdp/policy_test.go
+++ b/pdp/policy_test.go
@@ -764,7 +764,7 @@ func TestPolicyMarshalWithDepth(t *testing.T) {
 	}
 
 	// depth = 0, visible policy
-	expectMarshal := `{"ord":0,"id":"test","rules":[]}`
+	expectMarshal := `{"ord":0,"id":"test","target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectRCA"},"rules":[]}`
 	err = p.MarshalWithDepth(&buf, 0)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)
@@ -776,8 +776,8 @@ func TestPolicyMarshalWithDepth(t *testing.T) {
 	}
 
 	// show children, visible policy
-	expectChildren := `{"ord":0,"id":"first"},{"ord":1,"id":"second"},{"ord":2,"id":"third"}`
-	expectWithC := `{"ord":0,"id":"test","rules":[` + expectChildren + `]}`
+	expectChildren := `{"ord":0,"id":"first","target":{},"obligations":null},{"ord":1,"id":"second","target":{},"obligations":null},{"ord":2,"id":"third","target":{},"obligations":null}`
+	expectWithC := `{"ord":0,"id":"test","target":{},"obligations":null,"algorithm":{"type":"firstApplicableEffectRCA"},"rules":[` + expectChildren + `]}`
 	err = p.MarshalWithDepth(&buf2, 1)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)

--- a/pdp/rule.go
+++ b/pdp/rule.go
@@ -86,7 +86,7 @@ func (r Rule) MarshalWithDepth(out io.Writer, depth int) error {
 		ID:          r.id,
 		Target:      r.target,
 		Obligations: r.obligations,
-		Effect:      effectName[r.effect],
+		Effect:      effectNames[r.effect],
 	})
 	if err != nil {
 		return bindErrorf(err, "rid=\"%s\"", r.id)

--- a/pdp/rule.go
+++ b/pdp/rule.go
@@ -86,6 +86,7 @@ func (r Rule) MarshalWithDepth(out io.Writer, depth int) error {
 		ID:          r.id,
 		Target:      r.target,
 		Obligations: r.obligations,
+		Effect:      effectName[r.effect],
 	})
 	if err != nil {
 		return bindErrorf(err, "rid=\"%s\"", r.id)

--- a/pdp/rule.go
+++ b/pdp/rule.go
@@ -81,9 +81,11 @@ func (r Rule) MarshalWithDepth(out io.Writer, depth int) error {
 	if depth < 0 {
 		return newMarshalInvalidDepthError(depth)
 	}
-	rjson, err := json.Marshal(storageNodeFmt{
-		Ord: r.ord,
-		ID:  r.id,
+	rjson, err := json.Marshal(storageRuleFmt{
+		Ord:         r.ord,
+		ID:          r.id,
+		Target:      r.target,
+		Obligations: r.obligations,
 	})
 	if err != nil {
 		return bindErrorf(err, "rid=\"%s\"", r.id)

--- a/pdp/rule_test.go
+++ b/pdp/rule_test.go
@@ -59,7 +59,7 @@ func TestRuleMarshalWithDepth(t *testing.T) {
 	}
 
 	// good depth, visible rule
-	expectMarshal := `{"ord":32,"id":"one","target":{},"obligations":null}`
+	expectMarshal := `{"ord":32,"id":"one","target":{},"obligations":null,"effect":"Deny"}`
 	err = rule.MarshalWithDepth(&buf, 0)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)

--- a/pdp/rule_test.go
+++ b/pdp/rule_test.go
@@ -59,7 +59,7 @@ func TestRuleMarshalWithDepth(t *testing.T) {
 	}
 
 	// good depth, visible rule
-	expectMarshal := `{"ord":32,"id":"one"}`
+	expectMarshal := `{"ord":32,"id":"one","target":{},"obligations":null}`
 	err = rule.MarshalWithDepth(&buf, 0)
 	if err != nil {
 		t.Errorf("Expecting no error, got %v", err)


### PR DESCRIPTION
I added MarshalJSON functions to the algorithms to easily marshal evaluables.
I'm under the assumption that recursive algorithms like Mapper wouldn't be very deep and therefore wouldn't have huge memory impact when marshalled to string