### PR TITLE
plugin/policy: remove precedence of action log from the 1st validation

### DIFF
--- a/contrib/coredns/policy/attrholder.go
+++ b/contrib/coredns/policy/attrholder.go
@@ -83,10 +83,7 @@ func (ah *attrHolder) addResponse(r *pdp.Response, respip bool) {
 	l := len(r.Obligation)
 	switch r.Effect {
 	case pdp.Response_PERMIT:
-		// don't overwrite "Log" action from previous validation
-		if ah.action != typeLog {
-			ah.action = typeAllow
-		}
+		ah.action = typeAllow
 		for i < l {
 			item := r.Obligation[i]
 			if item.Id == attrNameLog {

--- a/contrib/coredns/policy/attrholder_test.go
+++ b/contrib/coredns/policy/attrholder_test.go
@@ -392,8 +392,8 @@ func TestAllowActionAfterLogAction(t *testing.T) {
 	ah.addResponse(&pdp.Response{Effect: pdp.Response_PERMIT,
 		Obligation: []*pdp.Attribute{{Id: "log"}}}, false)
 	ah.addResponse(&pdp.Response{Effect: pdp.Response_PERMIT}, true)
-	if ah.action != typeLog {
-		t.Errorf("Unexpected action: expected=%d, actual=%d", typeLog, ah.action)
+	if ah.action != typeAllow {
+		t.Errorf("Unexpected action: expected=%d, actual=%d", typeAllow, ah.action)
 	}
 }
 

--- a/contrib/coredns/policy/metrics.go
+++ b/contrib/coredns/policy/metrics.go
@@ -255,6 +255,8 @@ func (pp *policyPlugin) SetupMetrics(c *caddy.Controller) error {
 			if m, ok := mh.(*metrics.Metrics); ok {
 				metricsOnce.Do(func() {
 					m.MustRegister(globalAttrGauge.pgv)
+					// The globalAttrGauge is started once and is not stopped
+					// until process termination
 					globalAttrGauge.Start(DefaultEraseInterval, DefaultQueryChanSize)
 				})
 				globalAttrGauge.AddAttributes(attrNames...)

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -133,14 +133,7 @@ func TestPolicy(t *testing.T) {
 			status:     dns.RcodeSuccess,
 			err:        nil,
 			attrs: []*pdp.Attribute{
-				{Id: attrNameDomainName, Value: "test.com"},
-				{Id: attrNameDNSQtype, Value: "1"},
 				{Id: attrNameSourceIP, Value: "10.240.0.1"},
-				{Id: attrNameAddress, Value: "10.240.0.1"},
-				{Id: AttrNamePolicyID, Value: "cafecafe"},
-				{Id: attrNameLog, Value: "true"},
-				{Id: attrNamePolicyAction, Value: "2"},
-				{Id: attrNameType, Value: typeValueResponse},
 			},
 		},
 		{


### PR DESCRIPTION
 - the action from the last validation wins. The appropriate policy
   should be uploaded to PDP
 - added comment to metrics