### PR TITLE
WIP: CoreDNS Tight integration

### DIFF
--- a/pdpserver/server/server.go
+++ b/pdpserver/server/server.go
@@ -160,6 +160,8 @@ type options struct {
 
 // Server structure is PDP server object
 type Server struct {
+	PDPService
+
 	sync.RWMutex
 
 	opts options
@@ -175,8 +177,8 @@ type Server struct {
 
 	q *queue
 
-	p *pdp.PolicyStorage
-	c *pdp.LocalContentStorage
+	//	p *pdp.PolicyStorage
+	//	c *pdp.LocalContentStorage
 
 	softMemWarn *time.Time
 	backMemWarn *time.Time
@@ -214,18 +216,20 @@ func NewServer(opts ...Option) *Server {
 		pool = makeBytePool(int(o.maxResponseSize), false)
 	}
 
-	return &Server{
+	s := &Server{
 		opts:                o,
 		errCh:               make(chan error, 100),
 		q:                   newQueue(),
-		c:                   pdp.NewLocalContentStorage(nil),
 		memProfBaseDumpDone: memProfBaseDumpDone,
 		pool:                pool,
 	}
+	s.PDPService.opts = o
+	s.c = pdp.NewLocalContentStorage(nil)
+	return s
 }
 
 // LoadPolicies loads policies from file
-func (s *Server) LoadPolicies(path string) error {
+func (s *PDPService) LoadPolicies(path string) error {
 	if len(path) <= 0 {
 		return nil
 	}
@@ -268,7 +272,7 @@ func (s *Server) ReadPolicies(r io.Reader) error {
 }
 
 // LoadContent loads content from files
-func (s *Server) LoadContent(paths []string) error {
+func (s *PDPService) LoadContent(paths []string) error {
 	items := []*pdp.LocalContent{}
 	for _, path := range paths {
 		err := func() error {

--- a/pdpserver/server/service.go
+++ b/pdpserver/server/service.go
@@ -5,45 +5,41 @@ import (
 	"github.com/infobloxopen/themis/pdp"
 	pb "github.com/infobloxopen/themis/pdp-service"
 	"github.com/infobloxopen/themis/pdp/ast"
+	"github.com/infobloxopen/themis/pdp/jcon"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 )
 
 type PDPService struct {
 	sync.RWMutex
-	opts options
+
+	parser ast.Parser
+	logger *log.Logger
 
 	p *pdp.PolicyStorage
 	c *pdp.LocalContentStorage
 }
 
-func NewBuiltinPDPService(policyFile string, contentFiles []string) *PDPService {
-	o := options{
-		logger:              log.StandardLogger(),
-		service:             ":5555",
-		memStatsLogInterval: -1 * time.Second,
-		maxResponseSize:     10240,
+func NewBuiltinPDPService(policyFile string, contentFiles []string, logger *log.Logger) *PDPService {
+	s := &PDPService{
+		logger: logger,
+		c:      pdp.NewLocalContentStorage(nil),
 	}
 
 	ext := filepath.Ext(policyFile)
 	switch ext {
 	case ".json":
-		o.parser = ast.NewJSONParser()
+		s.parser = ast.NewJSONParser()
 	case ".yaml":
-		o.parser = ast.NewYAMLParser()
+		s.parser = ast.NewYAMLParser()
 	}
 
-	if o.parser == nil {
-		o.parser = ast.NewYAMLParser()
-	}
-
-	s := &PDPService{
-		c:    pdp.NewLocalContentStorage(nil),
-		opts: o,
+	if s.parser == nil {
+		s.parser = ast.NewYAMLParser()
 	}
 
 	log.SetLevel(log.DebugLevel)
@@ -60,6 +56,63 @@ func NewBuiltinPDPService(policyFile string, contentFiles []string) *PDPService 
 	}
 
 	return s
+}
+
+// LoadPolicies loads policies from file
+func (s *PDPService) LoadPolicies(path string) error {
+	if len(path) <= 0 {
+		return nil
+	}
+
+	s.logger.WithField("policy", path).Info("Loading policy")
+	pf, err := os.Open(path)
+	if err != nil {
+		s.logger.WithFields(log.Fields{"policy": path, "error": err}).Error("Failed load policy")
+		return err
+	}
+
+	s.logger.WithField("policy", path).Info("Parsing policy")
+	p, err := s.parser.Unmarshal(pf, nil)
+	if err != nil {
+		s.logger.WithFields(log.Fields{"policy": path, "error": err}).Error("Failed parse policy")
+		return err
+	}
+
+	s.p = p
+
+	return nil
+}
+
+// LoadContent loads content from files
+func (s *PDPService) LoadContent(paths []string) error {
+	items := []*pdp.LocalContent{}
+	for _, path := range paths {
+		err := func() error {
+			s.logger.WithField("content", path).Info("Opening content")
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+
+			defer f.Close()
+
+			s.logger.WithField("content", path).Info("Parsing content")
+			item, err := jcon.Unmarshal(f, nil)
+			if err != nil {
+				return err
+			}
+
+			items = append(items, item)
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	s.c = pdp.NewLocalContentStorage(items)
+
+	return nil
 }
 
 func (s *PDPService) newContext(c *pdp.LocalContentStorage, in []byte) (*pdp.Context, error) {
@@ -178,14 +231,14 @@ func (s *Server) rawValidateToBuffer(p *pdp.PolicyStorage, c *pdp.LocalContentSt
 		return makeFailureResponseWithBuffer(out, err)
 	}
 
-	if s.opts.logger.Level >= log.DebugLevel {
-		s.opts.logger.WithField("context", ctx).Debug("Request context")
+	if s.logger.Level >= log.DebugLevel {
+		s.logger.WithField("context", ctx).Debug("Request context")
 	}
 
 	r := p.Root().Calculate(ctx)
 
-	if s.opts.logger.Level >= log.DebugLevel {
-		s.opts.logger.WithFields(log.Fields{
+	if s.logger.Level >= log.DebugLevel {
+		s.logger.WithFields(log.Fields{
 			"effect": pdp.EffectNameFromEnum(r.Effect),
 			"reason": r.Status,
 			"obligations": obligations{

--- a/pdpserver/server/service.go
+++ b/pdpserver/server/service.go
@@ -2,16 +2,67 @@ package server
 
 import (
 	"fmt"
-	"strings"
-
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
-
 	"github.com/infobloxopen/themis/pdp"
 	pb "github.com/infobloxopen/themis/pdp-service"
+	"github.com/infobloxopen/themis/pdp/ast"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 )
 
-func (s *Server) newContext(c *pdp.LocalContentStorage, in []byte) (*pdp.Context, error) {
+type PDPService struct {
+	sync.RWMutex
+	opts options
+
+	p *pdp.PolicyStorage
+	c *pdp.LocalContentStorage
+}
+
+func NewBuiltinPDPService(policyFile string, contentFiles []string) *PDPService {
+	o := options{
+		logger:              log.StandardLogger(),
+		service:             ":5555",
+		memStatsLogInterval: -1 * time.Second,
+		maxResponseSize:     10240,
+	}
+
+	ext := filepath.Ext(policyFile)
+	switch ext {
+	case ".json":
+		o.parser = ast.NewJSONParser()
+	case ".yaml":
+		o.parser = ast.NewYAMLParser()
+	}
+
+	if o.parser == nil {
+		o.parser = ast.NewYAMLParser()
+	}
+
+	s := &PDPService{
+		c:    pdp.NewLocalContentStorage(nil),
+		opts: o,
+	}
+
+	log.SetLevel(log.DebugLevel)
+	err := s.LoadPolicies(policyFile)
+	if err != nil {
+		return nil
+	}
+
+	if contentFiles != nil && len(contentFiles) > 0 {
+		err = s.LoadContent(contentFiles)
+		if err != nil {
+			return nil
+		}
+	}
+
+	return s
+}
+
+func (s *PDPService) newContext(c *pdp.LocalContentStorage, in []byte) (*pdp.Context, error) {
 	ctx, err := pdp.NewContextFromBytes(c, in)
 	if err != nil {
 		return nil, newContextCreationError(err)
@@ -47,7 +98,7 @@ func makeFailureResponseWithBuffer(b []byte, err error) []byte {
 	return b[:n]
 }
 
-func (s *Server) rawValidate(p *pdp.PolicyStorage, c *pdp.LocalContentStorage, in []byte) []byte {
+func (s *PDPService) rawValidate(p *pdp.PolicyStorage, c *pdp.LocalContentStorage, in []byte) []byte {
 	if p == nil {
 		return makeFailureResponse(newMissingPolicyError())
 	}
@@ -154,7 +205,7 @@ func (s *Server) rawValidateToBuffer(p *pdp.PolicyStorage, c *pdp.LocalContentSt
 
 // Validate is a server handler for gRPC call
 // It handles PDP decision requests
-func (s *Server) Validate(ctx context.Context, in *pb.Msg) (*pb.Msg, error) {
+func (s *PDPService) Validate(ctx context.Context, in *pb.Msg) (*pb.Msg, error) {
 	s.RLock()
 	p := s.p
 	c := s.c

--- a/pep/builtin_client.go
+++ b/pep/builtin_client.go
@@ -6,6 +6,7 @@ import (
 
 	pb "github.com/infobloxopen/themis/pdp-service"
 	ps "github.com/infobloxopen/themis/pdpserver/server"
+	log "github.com/sirupsen/logrus"
 )
 
 type builtinClient struct {
@@ -13,9 +14,9 @@ type builtinClient struct {
 	pool bytePool
 }
 
-func NewBuiltinClient(policyFile string, contentFiles []string) *builtinClient {
+func NewBuiltinClient(policyFile string, contentFiles []string, logger *log.Logger) *builtinClient {
 	fmt.Printf("pep client NewBuiltinClient() called..........\n")
-	s := ps.NewBuiltinPDPService(policyFile, contentFiles)
+	s := ps.NewBuiltinPDPService(policyFile, contentFiles, logger)
 	return &builtinClient{
 		s:    s,
 		pool: makeBytePool(10240, true),

--- a/pep/builtin_client.go
+++ b/pep/builtin_client.go
@@ -1,0 +1,60 @@
+package pep
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+
+	pb "github.com/infobloxopen/themis/pdp-service"
+	ps "github.com/infobloxopen/themis/pdpserver/server"
+)
+
+type builtinClient struct {
+	s    *ps.PDPService
+	pool bytePool
+}
+
+func NewBuiltinClient(policyFile string, contentFiles []string) *builtinClient {
+	fmt.Printf("pep client NewBuiltinClient() called..........\n")
+	s := ps.NewBuiltinPDPService(policyFile, contentFiles)
+	return &builtinClient{
+		s:    s,
+		pool: makeBytePool(10240, true),
+	}
+}
+
+func (c *builtinClient) Connect(addr string) error {
+	fmt.Printf("pep client Connect() called..........\n")
+	return nil
+}
+
+func (c *builtinClient) Close() {
+	fmt.Printf("pep client Close() called..........\n")
+}
+
+func (c *builtinClient) Validate(in, out interface{}) error {
+	fmt.Printf("pep client Validate() called..........\n")
+	if c.s == nil {
+		return ErrorNotConnected
+	}
+
+	var b []byte
+	switch in.(type) {
+	default:
+		b = c.pool.Get()
+		defer c.pool.Put(b)
+
+	case []byte, pb.Msg, *pb.Msg:
+	}
+
+	req, err := makeRequest(in, b)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.s.Validate(context.Background(), &req)
+	if err != nil {
+		return err
+	}
+
+	return fillResponse(*res, out)
+}

--- a/pep/builtin_client.go
+++ b/pep/builtin_client.go
@@ -1,60 +1,97 @@
 package pep
 
 import (
-	"fmt"
 	"golang.org/x/net/context"
 
+	"github.com/allegro/bigcache"
 	pb "github.com/infobloxopen/themis/pdp-service"
 	ps "github.com/infobloxopen/themis/pdpserver/server"
-	log "github.com/sirupsen/logrus"
 )
 
 type builtinClient struct {
-	s    *ps.PDPService
+	s *ps.PDPService
+
 	pool bytePool
+
+	cache *bigcache.BigCache
+
+	opts options
 }
 
-func NewBuiltinClient(policyFile string, contentFiles []string, logger *log.Logger) *builtinClient {
-	fmt.Printf("pep client NewBuiltinClient() called..........\n")
-	s := ps.NewBuiltinPDPService(policyFile, contentFiles, logger)
-	return &builtinClient{
+func newBuiltinClient(opts options) *builtinClient {
+	s := ps.NewBuiltinPDPService(opts.policyFile, opts.contentFiles)
+	c := &builtinClient{
 		s:    s,
-		pool: makeBytePool(10240, true),
+		opts: opts,
 	}
+
+	if !opts.autoRequestSize {
+		c.pool = makeBytePool(int(opts.maxRequestSize), opts.noPool)
+	}
+
+	return c
 }
 
 func (c *builtinClient) Connect(addr string) error {
-	fmt.Printf("pep client Connect() called..........\n")
+	cache, err := newCacheFromOptions(c.opts)
+	if err != nil {
+		return err
+	}
+	c.cache = cache
+
 	return nil
 }
 
 func (c *builtinClient) Close() {
-	fmt.Printf("pep client Close() called..........\n")
+	if c.cache != nil {
+		c.cache.Reset()
+		c.cache = nil
+	}
+
+	c.s = nil
 }
 
 func (c *builtinClient) Validate(in, out interface{}) error {
-	fmt.Printf("pep client Validate() called..........\n")
 	if c.s == nil {
 		return ErrorNotConnected
 	}
 
-	var b []byte
-	switch in.(type) {
-	default:
-		b = c.pool.Get()
-		defer c.pool.Put(b)
+	var (
+		req pb.Msg
+		err error
+	)
 
-	case []byte, pb.Msg, *pb.Msg:
+	if c.opts.autoRequestSize {
+		req, err = makeRequest(in)
+	} else {
+		var b []byte
+		switch in.(type) {
+		default:
+			b = c.pool.Get()
+			defer c.pool.Put(b)
+
+		case []byte, pb.Msg, *pb.Msg:
+		}
+
+		req, err = makeRequestWithBuffer(in, b)
 	}
-
-	req, err := makeRequest(in, b)
 	if err != nil {
 		return err
+	}
+
+	if c.cache != nil {
+		if b, err := c.cache.Get(string(req.Body)); err == nil {
+			return fillResponse(pb.Msg{Body: b}, out)
+		}
 	}
 
 	res, err := c.s.Validate(context.Background(), &req)
 	if err != nil {
 		return err
+	}
+
+	if c.cache != nil {
+		c.cache.Set(string(req.Body), res.Body)
 	}
 
 	return fillResponse(*res, out)

--- a/pep/client.go
+++ b/pep/client.go
@@ -183,6 +183,22 @@ func WithCacheTTLAndMaxSize(ttl time.Duration, size int) Option {
 	}
 }
 
+// WithPolicyFile returns an Option which specifies policy file used by
+// the builtinClient.
+func WithPolicyFile(policyFile string) Option {
+	return func(o *options) {
+		o.policyFile = policyFile
+	}
+}
+
+// WithContentFiles returns an Option which specifies content files used by
+// the builtinClient.
+func WithContentFiles(contentFiles []string) Option {
+	return func(o *options) {
+		o.contentFiles = contentFiles
+	}
+}
+
 const (
 	noBalancer = iota
 	roundRobinBalancer
@@ -202,6 +218,8 @@ type options struct {
 	cache           bool
 	cacheTTL        time.Duration
 	cacheMaxSize    int
+	policyFile      string
+	contentFiles    []string
 }
 
 // NewClient creates client instance using given options.
@@ -212,6 +230,10 @@ func NewClient(opts ...Option) Client {
 	}
 	for _, opt := range opts {
 		opt(&o)
+	}
+
+	if o.policyFile != "" {
+		return newBuiltinClient(o)
 	}
 
 	if o.maxStreams > 0 {


### PR DESCRIPTION
This is a WIP for the use of github.com/coredns/policy, the goal of which is to create a CoreDNS policy plugin that process policy request using a linked in version of Themis.

This PR addresses the comments in https://github.com/infobloxopen/themis/pull/177

I have moved some methods from pdpserver/server/server.go to pdpserver/server/service.go, so it makes it a bit more difficult to review. If you like, I can move them back for the purpose of this review.

The base branch for this PR is https://github.com/infobloxopen/themis/tree/coredns-tight so that we can use that for ongoing development.
