### PR TITLE
Removed "testing" package from production code

### DIFF
--- a/pdp/assignment.go
+++ b/pdp/assignment.go
@@ -3,7 +3,6 @@ package pdp
 import (
 	"fmt"
 	"net"
-	"testing"
 
 	"github.com/infobloxopen/go-trees/domain"
 	"github.com/infobloxopen/go-trees/domaintree"
@@ -486,16 +485,21 @@ func serializeAssignmentsForAssert(desc string, expected bool, a []AttributeAssi
 	return out, nil
 }
 
-func AssertAttributeAssignments(t *testing.T, desc string, a []AttributeAssignment, e ...AttributeAssignment) {
+type errorF interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+func AssertAttributeAssignments(ef errorF, desc string, a []AttributeAssignment, e ...AttributeAssignment) {
 	sa, err := serializeAssignmentsForAssert(desc, false, a)
 	if err != nil {
-		t.Error(err)
+		ef.Error(err)
 		return
 	}
 
 	se, err := serializeAssignmentsForAssert(desc, true, e)
 	if err != nil {
-		t.Error(err)
+		ef.Error(err)
 		return
 	}
 
@@ -511,6 +515,6 @@ func AssertAttributeAssignments(t *testing.T, desc string, a []AttributeAssignme
 	}
 
 	if len(diff) > 0 {
-		t.Errorf("\"%s\" doesn't match:\n%s", desc, diff)
+		ef.Errorf("\"%s\" doesn't match:\n%s", desc, diff)
 	}
 }


### PR DESCRIPTION
Package "testing" in production code of PDP library brings some unwanted options to every executable which uses the library. Result looks like:
```
$ pdpserver -help
Usage of pdpserver:
  -auto-response
    	automatic respose buffer allocation
...
  -test.bench regexp
    	run only benchmarks matching regexp
  -test.benchmem
    	print memory allocations for benchmarks
  -test.benchtime d
    	run each benchmark for duration d (default 1s)
...
```

The patch removes "testing" together with the options.