### PR TITLE
recover PR#188 logic

### DIFF
--- a/contrib/coredns/policy/attrholder.go
+++ b/contrib/coredns/policy/attrholder.go
@@ -251,9 +251,6 @@ func (ah *attrHolder) addIPRes(r *pdp.Response) {
 		ah.action = actionInvalid
 
 	case pdp.EffectPermit:
-		if ah.action == actionLog {
-			break
-		}
 		ah.action = actionAllow
 
 		for _, o := range r.Obligations {

--- a/contrib/coredns/policy/attrholder_test.go
+++ b/contrib/coredns/policy/attrholder_test.go
@@ -256,7 +256,7 @@ func TestActionIpResponse(t *testing.T) {
 				Effect: pdp.EffectPermit,
 			},
 			initAction: actionLog,
-			action:     actionLog,
+			action:     actionAllow,
 		},
 		{
 			res: &pdp.Response{


### PR DESCRIPTION
recover PR #188 - plugin/policy: remove precedence of action log from the 1st validation