### PR TITLE
policy plugin: reset ttl on log action

### DIFF
--- a/contrib/coredns/policy/dns.go
+++ b/contrib/coredns/policy/dns.go
@@ -96,6 +96,21 @@ func clearECS(r *dns.Msg) {
 	o.Option = option
 }
 
+func resetTTL(r *dns.Msg) *dns.Msg {
+	if r == nil {
+		return nil
+	}
+
+	for _, rr := range r.Answer {
+		switch rr := rr.(type) {
+		case *dns.A, *dns.AAAA:
+			rr.Header().Ttl = 0
+		}
+	}
+
+	return r
+}
+
 func (p *policyPlugin) setRedirectQueryAnswer(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, dst string) (int, error) {
 	var rr dns.RR
 

--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -179,8 +179,12 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 	}
 
 	switch ah.action {
-	case actionAllow, actionLog:
+	case actionAllow:
 		r = respMsg
+		return dns.RcodeSuccess, nil
+
+	case actionLog:
+		r = resetTTL(respMsg)
 		return dns.RcodeSuccess, nil
 
 	case actionRedirect:


### PR DESCRIPTION
 - the response should not be cached for log action, client should
   send the query every time to make sure each query is logged