### PR TITLE
POC: PEP Client Validate return Cached flag

### DIFF
--- a/contrib/coredns/policy/attrholder.go
+++ b/contrib/coredns/policy/attrholder.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strconv"
 
@@ -134,7 +133,7 @@ func (ah *attrHolder) addDnRes(r *pdp.Response, custAttrs map[string]custAttr) {
 
 	switch r.Effect {
 	default:
-		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		log.Errorf("PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
 		ah.action = actionInvalid
 
 	case pdp.EffectPermit:
@@ -203,7 +202,7 @@ func (ah *attrHolder) addRedirect(attr pdp.AttributeAssignment) {
 	ah.action = actionRedirect
 	dst, err := attr.GetString(emptyCtx)
 	if err != nil {
-		log.Printf("[ERROR] Action: %s, Destination: %s (%s)", actionNames[ah.action], serializeOrPanic(attr), err)
+		log.Errorf("Action: %s, Destination: %s (%s)", actionNames[ah.action], serializeOrPanic(attr), err)
 
 		ah.action = actionInvalid
 		return
@@ -247,7 +246,7 @@ func (ah *attrHolder) addIPReq(ip net.IP) {
 func (ah *attrHolder) addIPRes(r *pdp.Response) {
 	switch r.Effect {
 	default:
-		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		log.Errorf("PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
 		ah.action = actionInvalid
 
 	case pdp.EffectPermit:

--- a/contrib/coredns/policy/client.go
+++ b/contrib/coredns/policy/client.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"log"
 	"sync/atomic"
 
 	"github.com/coredns/coredns/plugin/pkg/trace"
@@ -11,7 +10,7 @@ import (
 
 // connect establishes connection to PDP server.
 func (p *policyPlugin) connect() error {
-	log.Printf("[DEBUG] Connecting %v", p)
+	log.Debugf("Connecting %v", p)
 
 	for _, addr := range p.conf.endpoints {
 		p.connAttempts[addr] = new(uint32)
@@ -77,24 +76,24 @@ func (p *policyPlugin) validate(ah *attrHolder, a []pdp.AttributeAssignment) err
 	}
 
 	if p.conf.log {
-		log.Printf("[INFO] PDP request: %+v", req)
+		log.Infof("PDP request: %+v", req)
 	}
 
-	res := pdp.Response{Obligations: a}
+	res := pep.CachedResponse{Response: pdp.Response{Obligations: a}}
 	err := p.pdp.Validate(req, &res)
 	if err != nil {
-		log.Printf("[ERROR] Policy validation failed due to error %s", err)
+		log.Errorf("Policy validation failed due to error %s", err)
 		return err
 	}
 
 	if p.conf.log {
-		log.Printf("[INFO] PDP response: %+v", res)
+		log.Infof("PDP response: %+v", res)
 	}
 
 	if len(ah.ipReq) > 0 {
-		ah.addIPRes(&res)
+		ah.addIPRes(&res.Response)
 	} else {
-		ah.addDnRes(&res, p.conf.custAttrs)
+		ah.addDnRes(&res.Response, p.conf.custAttrs)
 	}
 
 	return nil
@@ -104,9 +103,9 @@ func (p *policyPlugin) connStateCb(addr string, state int, err error) {
 	switch state {
 	default:
 		if err != nil {
-			log.Printf("[DEBUG] Unknown connection notification %s (%s)", addr, err)
+			log.Debugf("Unknown connection notification %s (%s)", addr, err)
 		} else {
-			log.Printf("[DEBUG] Unknown connection notification %s", addr)
+			log.Debugf("Unknown connection notification %s", addr)
 		}
 
 	case pep.StreamingConnectionEstablished:
@@ -116,10 +115,10 @@ func (p *policyPlugin) connStateCb(addr string, state int, err error) {
 		}
 		atomic.StoreUint32(ptr, 0)
 
-		log.Printf("[INFO] Connected to %s", addr)
+		log.Infof("Connected to %s", addr)
 
 	case pep.StreamingConnectionBroken:
-		log.Printf("[ERROR] Connection to %s has been broken", addr)
+		log.Errorf("Connection to %s has been broken", addr)
 
 	case pep.StreamingConnectionConnecting:
 		ptr, ok := p.connAttempts[addr]
@@ -129,11 +128,11 @@ func (p *policyPlugin) connStateCb(addr string, state int, err error) {
 		count := atomic.AddUint32(ptr, 1)
 
 		if count <= 1 {
-			log.Printf("[INFO] Connecting to %s", addr)
+			log.Infof("Connecting to %s", addr)
 		}
 
 		if count > 100 {
-			log.Printf("[ERROR] Connecting to %s", addr)
+			log.Errorf("Connecting to %s", addr)
 			atomic.StoreUint32(ptr, 1)
 		}
 
@@ -143,7 +142,7 @@ func (p *policyPlugin) connStateCb(addr string, state int, err error) {
 			ptr = p.unkConnAttempts
 		}
 		if atomic.LoadUint32(ptr) <= 1 {
-			log.Printf("[ERROR] Failed to connect to %s (%s)", addr, err)
+			log.Errorf("Failed to connect to %s (%s)", addr, err)
 		}
 	}
 }

--- a/contrib/coredns/policy/client_test.go
+++ b/contrib/coredns/policy/client_test.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/infobloxopen/themis/pdp/selector"
 	"github.com/infobloxopen/themis/pdpserver/server"
 	"github.com/miekg/dns"
-	log "github.com/sirupsen/logrus"
+	logr "github.com/sirupsen/logrus"
 )
 
 const testPolicy = `# Policy set for client interaction tests
@@ -348,9 +348,9 @@ func newServer(opts ...server.Option) *loggedServer {
 		b: new(bytes.Buffer),
 	}
 
-	logger := log.New()
+	logger := logr.New()
 	logger.Out = s.b
-	logger.Level = log.ErrorLevel
+	logger.Level = logr.ErrorLevel
 	opts = append(opts,
 		server.WithLogger(logger),
 	)

--- a/contrib/coredns/policy/dnstap.go
+++ b/contrib/coredns/policy/dnstap.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"log"
 	"strconv"
 	"time"
 
@@ -46,7 +45,7 @@ func newPolicyDnstapSender(io dnstap.IORoutine) dnstapSender {
 // message with IORoutine interface
 func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder) {
 	if w == nil || msg == nil {
-		log.Printf("[ERROR] Failed to create dnstap CR message - no DNS response message found")
+		log.Errorf("Failed to create dnstap CR message - no DNS response message found")
 		return
 	}
 
@@ -55,7 +54,7 @@ func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, 
 	b.Msg(msg)
 	crMsg, err := b.ToClientResponse()
 	if err != nil {
-		log.Printf("[ERROR] Failed to create dnstap CR message (%v)", err)
+		log.Errorf("Failed to create dnstap CR message (%v)", err)
 		return
 	}
 
@@ -67,7 +66,7 @@ func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, 
 	if ah != nil {
 		extra, err = proto.Marshal(&pb.Extra{Attrs: ah.makeDnstapReport()})
 		if err != nil {
-			log.Printf("[ERROR] Failed to create extra data for dnstap CR message (%v)", err)
+			log.Errorf("Failed to create extra data for dnstap CR message (%v)", err)
 		}
 	}
 	dnstapMsg := tap.Dnstap{Type: &t, Message: crMsg, Extra: extra}

--- a/contrib/coredns/policy/metrics.go
+++ b/contrib/coredns/policy/metrics.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"errors"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -133,7 +132,7 @@ func (g *AttrGauge) Start(tickInt time.Duration, chSize int) {
 				case <-timer.C:
 					eCnt := g.tick()
 					if eCnt != 0 {
-						log.Printf("[WARN] Policy metrics: %d queries was skipped", eCnt)
+						log.Warningf("Policy metrics: %d queries was skipped", eCnt)
 					}
 					timer.Reset(tickInt)
 				}

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -3,7 +3,7 @@ package policy
 import (
 	"bytes"
 	"fmt"
-	"log"
+	logr "github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"sync/atomic"
@@ -804,7 +804,7 @@ type logGrabber struct {
 
 func newLogGrabber() *logGrabber {
 	b := new(bytes.Buffer)
-	log.SetOutput(b)
+	logr.SetOutput(b)
 
 	return &logGrabber{
 		b: b,
@@ -812,7 +812,7 @@ func newLogGrabber() *logGrabber {
 }
 
 func (g *logGrabber) Release() string {
-	log.SetOutput(os.Stderr)
+	logr.SetOutput(os.Stderr)
 
 	return g.b.String()
 }

--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -4,9 +4,11 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/dnstap"
-
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/mholt/caddy"
 )
+
+var log = clog.NewWithPlugin("policy")
 
 func init() {
 	caddy.RegisterPlugin("policy", caddy.Plugin{

--- a/pep/streaming_client.go
+++ b/pep/streaming_client.go
@@ -134,8 +134,15 @@ func (c *streamingClient) Validate(in, out interface{}) error {
 	}
 
 	if c.cache != nil {
-		if b, err := c.cache.Get(string(m.Body)); err == nil {
-			return fillResponse(pb.Msg{Body: b}, out)
+		var b []byte
+		if b, err = c.cache.Get(string(m.Body)); err == nil {
+			if err = fillResponse(pb.Msg{Body: b}, out); err == nil {
+				switch r := out.(type) {
+				case *CachedResponse:
+					r.Cached = true
+				}
+			}
+			return err
 		}
 	}
 

--- a/pep/unary_client.go
+++ b/pep/unary_client.go
@@ -148,8 +148,15 @@ func (c *unaryClient) Validate(in, out interface{}) error {
 	}
 
 	if c.cache != nil {
-		if b, err := c.cache.Get(string(req.Body)); err == nil {
-			return fillResponse(pb.Msg{Body: b}, out)
+		var b []byte
+		if b, err = c.cache.Get(string(req.Body)); err == nil {
+			if err = fillResponse(pb.Msg{Body: b}, out); err == nil {
+				switch r := out.(type) {
+				case *CachedResponse:
+					r.Cached = true
+				}
+			}
+			return err
 		}
 	}
 


### PR DESCRIPTION
- Added pep.CachedResponse that encapsulate pdp.Response with
  the addition of a Cached flag. The default pep unary and
  streaming client updates Cached flag if a CacheResponse is
  specified.
- Updated CoreDNS policy plugin to use pep.CachedResponse
- (somewhat related)Updated CoreDNS policy plugin to use CoreDNS
  logger.