### PR TITLE
Updated CoreDNS plugin to use CoreDNS logger

### DIFF
--- a/contrib/coredns/policy/attrholder.go
+++ b/contrib/coredns/policy/attrholder.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strconv"
 
@@ -134,7 +133,7 @@ func (ah *attrHolder) addDnRes(r *pdp.Response, custAttrs map[string]custAttr) {
 
 	switch r.Effect {
 	default:
-		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		log.Errorf("PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
 		ah.action = actionInvalid
 
 	case pdp.EffectPermit:
@@ -203,7 +202,7 @@ func (ah *attrHolder) addRedirect(attr pdp.AttributeAssignment) {
 	ah.action = actionRedirect
 	dst, err := attr.GetString(emptyCtx)
 	if err != nil {
-		log.Printf("[ERROR] Action: %s, Destination: %s (%s)", actionNames[ah.action], serializeOrPanic(attr), err)
+		log.Errorf("Action: %s, Destination: %s (%s)", actionNames[ah.action], serializeOrPanic(attr), err)
 
 		ah.action = actionInvalid
 		return
@@ -247,7 +246,7 @@ func (ah *attrHolder) addIPReq(ip net.IP) {
 func (ah *attrHolder) addIPRes(r *pdp.Response) {
 	switch r.Effect {
 	default:
-		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		log.Errorf("PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
 		ah.action = actionInvalid
 
 	case pdp.EffectPermit:

--- a/contrib/coredns/policy/client.go
+++ b/contrib/coredns/policy/client.go
@@ -10,7 +10,7 @@ import (
 
 // connect establishes connection to PDP server.
 func (p *policyPlugin) connect() error {
-	log.Debugf("Connecting %v", p)
+	log.Infof("Connecting %v", p)
 
 	for _, addr := range p.conf.endpoints {
 		p.connAttempts[addr] = new(uint32)
@@ -103,9 +103,9 @@ func (p *policyPlugin) connStateCb(addr string, state int, err error) {
 	switch state {
 	default:
 		if err != nil {
-			log.Debugf("Unknown connection notification %s (%s)", addr, err)
+			log.Infof("Unknown connection notification %s (%s)", addr, err)
 		} else {
-			log.Debugf("Unknown connection notification %s", addr)
+			log.Infof("Unknown connection notification %s", addr)
 		}
 
 	case pep.StreamingConnectionEstablished:

--- a/contrib/coredns/policy/client_test.go
+++ b/contrib/coredns/policy/client_test.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/infobloxopen/themis/pdp/selector"
 	"github.com/infobloxopen/themis/pdpserver/server"
 	"github.com/miekg/dns"
-	log "github.com/sirupsen/logrus"
+	logr "github.com/sirupsen/logrus"
 )
 
 const testPolicy = `# Policy set for client interaction tests
@@ -348,9 +348,9 @@ func newServer(opts ...server.Option) *loggedServer {
 		b: new(bytes.Buffer),
 	}
 
-	logger := log.New()
+	logger := logr.New()
 	logger.Out = s.b
-	logger.Level = log.ErrorLevel
+	logger.Level = logr.ErrorLevel
 	opts = append(opts,
 		server.WithLogger(logger),
 	)

--- a/contrib/coredns/policy/dnstap.go
+++ b/contrib/coredns/policy/dnstap.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"log"
 	"strconv"
 	"time"
 
@@ -46,7 +45,7 @@ func newPolicyDnstapSender(io dnstap.IORoutine) dnstapSender {
 // message with IORoutine interface
 func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder) {
 	if w == nil || msg == nil {
-		log.Printf("[ERROR] Failed to create dnstap CR message - no DNS response message found")
+		log.Errorf("Failed to create dnstap CR message - no DNS response message found")
 		return
 	}
 
@@ -55,7 +54,7 @@ func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, 
 	b.Msg(msg)
 	crMsg, err := b.ToClientResponse()
 	if err != nil {
-		log.Printf("[ERROR] Failed to create dnstap CR message (%v)", err)
+		log.Errorf("Failed to create dnstap CR message (%v)", err)
 		return
 	}
 
@@ -67,7 +66,7 @@ func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, 
 	if ah != nil {
 		extra, err = proto.Marshal(&pb.Extra{Attrs: ah.makeDnstapReport()})
 		if err != nil {
-			log.Printf("[ERROR] Failed to create extra data for dnstap CR message (%v)", err)
+			log.Errorf("Failed to create extra data for dnstap CR message (%v)", err)
 		}
 	}
 	dnstapMsg := tap.Dnstap{Type: &t, Message: crMsg, Extra: extra}

--- a/contrib/coredns/policy/metrics.go
+++ b/contrib/coredns/policy/metrics.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"errors"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -133,7 +132,7 @@ func (g *AttrGauge) Start(tickInt time.Duration, chSize int) {
 				case <-timer.C:
 					eCnt := g.tick()
 					if eCnt != 0 {
-						log.Printf("[WARN] Policy metrics: %d queries was skipped", eCnt)
+						log.Warningf("Policy metrics: %d queries was skipped", eCnt)
 					}
 					timer.Reset(tickInt)
 				}

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"sync/atomic"
@@ -14,6 +13,7 @@ import (
 	dtest "github.com/coredns/coredns/plugin/dnstap/test"
 	"github.com/infobloxopen/themis/pep"
 	"github.com/miekg/dns"
+	logr "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	pb "github.com/infobloxopen/themis/contrib/coredns/policy/dnstap"
@@ -804,7 +804,7 @@ type logGrabber struct {
 
 func newLogGrabber() *logGrabber {
 	b := new(bytes.Buffer)
-	log.SetOutput(b)
+	logr.SetOutput(b)
 
 	return &logGrabber{
 		b: b,
@@ -812,7 +812,7 @@ func newLogGrabber() *logGrabber {
 }
 
 func (g *logGrabber) Release() string {
-	log.SetOutput(os.Stderr)
+	logr.SetOutput(os.Stderr)
 
 	return g.b.String()
 }

--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -4,9 +4,11 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/dnstap"
-
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/mholt/caddy"
 )
+
+var log = clog.NewWithPlugin("policy")
 
 func init() {
 	caddy.RegisterPlugin("policy", caddy.Plugin{


### PR DESCRIPTION
Updating to use CoreDNS logger result in the following changes in log messages generated by the CoreDNS policy plugin:

- The log message will now include the name of the plugin, which is included in the log message after the log level label. For example:
From:
`2018/08/13 09:29:07 [INFO] PDP request: [(string)type:query (domain)domain_name:www.yahoo.com. (string)dns_qtype:1 (address)source_ip:127.0.0.1]`
To:
`2018/08/13 09:31:32 [INFO] plugin/policy: PDP request: [(string)type:query (domain)domain_name:www.yahoo.com. (string)dns_qtype:1 (address)source_ip:127.0.0.1]`
 
- In order to NOT have to enable debug for CoreDNS and all its plugins, a number of DEBUG messages is now changed to INFO messages. This is to maintain existing behavior - currently, policy plugin DEBUG messages are log.Printf()s and are therefore always output, however, with the CoreDNS logger, DEBUG messages are only output if debug mode is turned on.

- Warning messages will changed from being labelled as WARN to WARNING
 