### PR TITLE
Added WithOnCacheHitHandler PEP Option

### DIFF
--- a/contrib/coredns/policy/client.go
+++ b/contrib/coredns/policy/client.go
@@ -11,7 +11,7 @@ import (
 
 type pepCacheHitHandler struct{}
 
-func (ch *pepCacheHitHandler) Handle(req interface{}, resp interface{}) {
+func (ch *pepCacheHitHandler) Handle(req interface{}, resp interface{}, err error) {
 	log.Printf("[INFO] PEP responding to PDP request from cache %+v", req)
 }
 

--- a/contrib/coredns/policy/client.go
+++ b/contrib/coredns/policy/client.go
@@ -9,6 +9,16 @@ import (
 	"github.com/infobloxopen/themis/pep"
 )
 
+type pepCacheHitHandler struct{}
+
+func (ch *pepCacheHitHandler) Handle(req interface{}, resp interface{}) {
+	log.Printf("[INFO] PEP responding to PDP request from cache %+v", req)
+}
+
+func newPepCacheHitHandler() *pepCacheHitHandler {
+	return &pepCacheHitHandler{}
+}
+
 // connect establishes connection to PDP server.
 func (p *policyPlugin) connect() error {
 	log.Printf("[DEBUG] Connecting %v", p)
@@ -52,6 +62,10 @@ func (p *policyPlugin) connect() error {
 		if t, ok := p.trace.(trace.Trace); ok {
 			opts = append(opts, pep.WithTracer(t.Tracer()))
 		}
+	}
+
+	if p.conf.log {
+		opts = append(opts, pep.WithOnCacheHitHandler(newPepCacheHitHandler()))
 	}
 
 	p.pdp = pep.NewClient(opts...)

--- a/pep/client.go
+++ b/pep/client.go
@@ -184,7 +184,7 @@ func WithCacheTTLAndMaxSize(ttl time.Duration, size int) Option {
 }
 
 type OnCacheHitHandler interface {
-	Handle(req interface{}, resp interface{})
+	Handle(req interface{}, resp interface{}, err error)
 }
 
 func WithOnCacheHitHandler(h OnCacheHitHandler) Option {

--- a/pep/client.go
+++ b/pep/client.go
@@ -183,6 +183,16 @@ func WithCacheTTLAndMaxSize(ttl time.Duration, size int) Option {
 	}
 }
 
+type OnCacheHitHandler interface {
+	Handle(req interface{}, resp interface{})
+}
+
+func WithOnCacheHitHandler(h OnCacheHitHandler) Option {
+	return func(o *options) {
+		o.onCacheHitHandler = h
+	}
+}
+
 const (
 	noBalancer = iota
 	roundRobinBalancer
@@ -190,18 +200,19 @@ const (
 )
 
 type options struct {
-	addresses       []string
-	balancer        int
-	tracer          ot.Tracer
-	maxStreams      int
-	connTimeout     time.Duration
-	connStateCb     ConnectionStateNotificationCallback
-	autoRequestSize bool
-	maxRequestSize  uint32
-	noPool          bool
-	cache           bool
-	cacheTTL        time.Duration
-	cacheMaxSize    int
+	addresses         []string
+	balancer          int
+	tracer            ot.Tracer
+	maxStreams        int
+	connTimeout       time.Duration
+	connStateCb       ConnectionStateNotificationCallback
+	autoRequestSize   bool
+	maxRequestSize    uint32
+	noPool            bool
+	cache             bool
+	cacheTTL          time.Duration
+	cacheMaxSize      int
+	onCacheHitHandler OnCacheHitHandler
 }
 
 // NewClient creates client instance using given options.

--- a/pep/streaming_client.go
+++ b/pep/streaming_client.go
@@ -134,8 +134,15 @@ func (c *streamingClient) Validate(in, out interface{}) error {
 	}
 
 	if c.cache != nil {
-		if b, err := c.cache.Get(string(m.Body)); err == nil {
-			return fillResponse(pb.Msg{Body: b}, out)
+		var b []byte
+		if b, err = c.cache.Get(string(m.Body)); err == nil {
+			err = fillResponse(pb.Msg{Body: b}, out)
+			if err == nil {
+				if c.opts.onCacheHitHandler != nil {
+					c.opts.onCacheHitHandler.Handle(in, out)
+				}
+			}
+			return err
 		}
 	}
 

--- a/pep/streaming_client.go
+++ b/pep/streaming_client.go
@@ -137,9 +137,11 @@ func (c *streamingClient) Validate(in, out interface{}) error {
 		var b []byte
 		if b, err = c.cache.Get(string(m.Body)); err == nil {
 			err = fillResponse(pb.Msg{Body: b}, out)
-			if err == nil {
-				if c.opts.onCacheHitHandler != nil {
-					c.opts.onCacheHitHandler.Handle(in, out)
+			if c.opts.onCacheHitHandler != nil {
+				if err != nil {
+					c.opts.onCacheHitHandler.Handle(in, b, err)
+				} else {
+					c.opts.onCacheHitHandler.Handle(in, out, nil)
 				}
 			}
 			return err

--- a/pep/streaming_client_test.go
+++ b/pep/streaming_client_test.go
@@ -15,7 +15,11 @@ type testPepCacheHitHandler struct {
 	called int
 }
 
-func (ch *testPepCacheHitHandler) Handle(req interface{}, resp interface{}) {
+func (ch *testPepCacheHitHandler) Handle(req interface{}, resp interface{}, err error) {
+	if err != nil {
+		ch.t.Errorf("expected no error but got %s", err)
+	}
+
 	if r, ok := req.(decisionRequest); !ok {
 		ch.t.Errorf("expected descisionRequest but got %T", r)
 	} else {

--- a/pep/unary_client.go
+++ b/pep/unary_client.go
@@ -151,9 +151,11 @@ func (c *unaryClient) Validate(in, out interface{}) error {
 		var b []byte
 		if b, err = c.cache.Get(string(req.Body)); err == nil {
 			err = fillResponse(pb.Msg{Body: b}, out)
-			if err == nil {
-				if c.opts.onCacheHitHandler != nil {
-					c.opts.onCacheHitHandler.Handle(in, out)
+			if c.opts.onCacheHitHandler != nil {
+				if err != nil {
+					c.opts.onCacheHitHandler.Handle(in, b, err)
+				} else {
+					c.opts.onCacheHitHandler.Handle(in, out, nil)
 				}
 			}
 			return err

--- a/pep/unary_client.go
+++ b/pep/unary_client.go
@@ -148,8 +148,15 @@ func (c *unaryClient) Validate(in, out interface{}) error {
 	}
 
 	if c.cache != nil {
-		if b, err := c.cache.Get(string(req.Body)); err == nil {
-			return fillResponse(pb.Msg{Body: b}, out)
+		var b []byte
+		if b, err = c.cache.Get(string(req.Body)); err == nil {
+			err = fillResponse(pb.Msg{Body: b}, out)
+			if err == nil {
+				if c.opts.onCacheHitHandler != nil {
+					c.opts.onCacheHitHandler.Handle(in, out)
+				}
+			}
+			return err
 		}
 	}
 

--- a/pep/unary_client_test.go
+++ b/pep/unary_client_test.go
@@ -72,9 +72,11 @@ func TestUnaryClientValidationWithCache(t *testing.T) {
 		}
 	}()
 
+	ph := testPepCacheHitHandler{t: t}
 	c := NewClient(
 		WithMaxRequestSize(128),
 		WithCacheTTL(15*time.Minute),
+		WithOnCacheHitHandler(&ph),
 	)
 	err := c.Connect("127.0.0.1:5555")
 	if err != nil {
@@ -130,6 +132,10 @@ func TestUnaryClientValidationWithCache(t *testing.T) {
 
 	if out.Effect != pdp.EffectPermit || out.Reason != nil || out.X != "AllPermitRule" {
 		t.Errorf("got unexpected response: %s", out)
+	}
+
+	if ph.called != 1 {
+		t.Errorf("expect testPepCacheHitHandler called 1 time but got %d", ph.called)
 	}
 }
 


### PR DESCRIPTION
The option allows a handler func to be specified which
is called when a decision request is served from the
decision cache.

Also updated contrib/coredns/policy to make use of this to
log decision request processed via decision cache.