### PR TITLE
policy plugin: simplify dnstap tests

### DIFF
--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -549,7 +549,7 @@ func TestPolicyPluginServeDNSWithDnstap(t *testing.T) {
 	}
 	p.next = mp
 
-	io := newIORoutine(5000 * time.Millisecond)
+	io := newIORoutine()
 	p.tapIO = newPolicyDnstapSender(io)
 
 	g := newLogGrabber()


### PR DESCRIPTION
 - sendCRExtraMsg() doesn't spawn extra goroutine anymore, so there
   is not need to use channels and goroutines in testIORoutine
 - another reason is that dnstap related tests were failed sometimes
   with WARNING: DATA RACE. The problem was in testIORoutine logic