### PR TITLE
policy plugin: refactor attribute holder

### DIFF
--- a/contrib/coredns/policy/attributes.go
+++ b/contrib/coredns/policy/attributes.go
@@ -1,25 +1,137 @@
 package policy
 
-import "github.com/infobloxopen/themis/pdp"
+import (
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/infobloxopen/themis/pdp"
+)
+
+var errInvalidValue = errors.New("invalid attribute value")
 
 const (
-	attrNameType         = "type"
 	attrNameDomainName   = "domain_name"
 	attrNameDNSQtype     = "dns_qtype"
 	attrNameSourceIP     = "source_ip"
 	attrNameAddress      = "address"
-	attrNameLog          = "log"
-	attrNameRedirectTo   = "redirect_to"
-	attrNameRefuse       = "refuse"
-	attrNameDrop         = "drop"
 	attrNamePolicyAction = "policy_action"
-
-	typeValueQuery    = "query"
-	typeValueResponse = "response"
-
-	ednsAttrsStart = 3
-	ipReqAddrPos   = 1
+	attrNameRedirectTo   = "redirect_to"
+	attrNameLog          = "log"
 )
+
+const (
+	attrIndexDomainName = iota
+	attrIndexDNSQtype
+	attrIndexSourceIP
+	attrIndexAddress
+	attrIndexPolicyAction
+	attrIndexRedirectTo
+	attrIndexLog
+
+	attrIndexCount
+)
+
+const (
+	actionInvalid = iota
+	actionDrop
+	actionAllow
+	actionBlock
+	actionRedirect
+	actionRefuse
+
+	actionsTotal
+)
+
+type attrConf struct {
+	name  string
+	index int
+	value pdp.AttributeValue
+}
+
+const maxDnstapLists = 3
+
+const (
+	attrListTypeVal1 = iota
+	attrListTypeVal2
+	attrListTypeDefDecision
+	attrListTypeMetrics
+
+	attrListTypeDnstap //must be last
+)
+
+type attrsConfig struct {
+	attrInds  map[string]int
+	confLists [attrListTypeDnstap + maxDnstapLists][]attrConf
+}
+
+func newAttrsConfig() *attrsConfig {
+	return &attrsConfig{
+		attrInds: map[string]int{
+			attrNameDomainName:   attrIndexDomainName,
+			attrNameDNSQtype:     attrIndexDNSQtype,
+			attrNameSourceIP:     attrIndexSourceIP,
+			attrNameAddress:      attrIndexAddress,
+			attrNamePolicyAction: attrIndexPolicyAction,
+			attrNameRedirectTo:   attrIndexRedirectTo,
+			attrNameLog:          attrIndexLog,
+		},
+	}
+}
+
+func (ac *attrsConfig) provideIndex(name string) int {
+	ind, ok := ac.attrInds[name]
+	if !ok {
+		ind = len(ac.attrInds)
+		ac.attrInds[name] = ind
+	}
+	return ind
+}
+
+func (ac *attrsConfig) parseAttrList(listType int, argList ...string) error {
+	list := make([]attrConf, 0, len(argList))
+	for _, arg := range argList {
+		name, val, err := parseAttrArg(arg)
+		if err != nil {
+			return err
+		}
+		ind := ac.provideIndex(name)
+		list = append(list, attrConf{name: name, index: ind, value: val})
+	}
+	ac.confLists[listType] = list
+	return nil
+}
+
+func parseAttrArg(arg string) (name string, val pdp.AttributeValue, e error) {
+	tokens := strings.SplitN(arg, "=", 2)
+	name = tokens[0]
+	val = pdp.UndefinedValue
+	if len(tokens) < 2 {
+		return
+	}
+
+	if ip := net.ParseIP(tokens[1]); ip != nil {
+		val = pdp.MakeAddressValue(ip)
+		return
+	}
+
+	if num, err := strconv.ParseInt(tokens[1], 0, 64); err == nil {
+		val = pdp.MakeIntegerValue(num)
+		return
+	}
+
+	if str, err := strconv.Unquote(tokens[1]); err == nil {
+		val = pdp.MakeStringValue(str)
+		return
+	}
+
+	return "", pdp.UndefinedValue, errInvalidValue
+}
+
+func (ac *attrsConfig) hasMetrics() bool {
+	return len(ac.confLists[attrListTypeMetrics]) > 0
+}
 
 func serializeOrPanic(a pdp.AttributeAssignment) string {
 	v, err := a.GetValue()
@@ -33,29 +145,4 @@ func serializeOrPanic(a pdp.AttributeAssignment) string {
 	}
 
 	return s
-}
-
-type custAttr byte
-
-const (
-	custAttrEdns = 1 << iota
-	custAttrTransfer
-	custAttrDnstap
-	custAttrMetrics
-)
-
-func (a custAttr) isEdns() bool {
-	return a&custAttrEdns != 0
-}
-
-func (a custAttr) isTransfer() bool {
-	return a&custAttrTransfer != 0
-}
-
-func (a custAttr) isDnstap() bool {
-	return a&custAttrDnstap != 0
-}
-
-func (a custAttr) isMetrics() bool {
-	return a&custAttrMetrics != 0
 }

--- a/contrib/coredns/policy/attributes_test.go
+++ b/contrib/coredns/policy/attributes_test.go
@@ -22,16 +22,116 @@ func TestSerializeOrPanic(t *testing.T) {
 	}, "Undefined")
 }
 
-func TestCustAttr(t *testing.T) {
-	if !custAttr(custAttrEdns).isEdns() {
-		t.Errorf("expected %d is EDNS", custAttrEdns)
+func TestNewAttrsConfig(t *testing.T) {
+	cfg := newAttrsConfig()
+	if len(cfg.attrInds) != attrIndexCount {
+		t.Errorf("Incorrect initialization of attribute map")
+	}
+}
+
+func TestProvideIndex(t *testing.T) {
+	cfg := newAttrsConfig()
+	stdlen := len(cfg.attrInds)
+
+	tcs := []struct {
+		name string
+		ind  int
+	}{
+		{attrNamePolicyAction, attrIndexPolicyAction},
+		{attrNameSourceIP, attrIndexSourceIP},
+		{attrNameLog, attrIndexLog},
+		{attrNameDomainName, attrIndexDomainName},
+		{attrNameAddress, attrIndexAddress},
+		{attrNameRedirectTo, attrIndexRedirectTo},
+		{attrNameDNSQtype, attrIndexDNSQtype},
+		{"NewAttribute1", stdlen},
+		{"NewAttribute2", stdlen + 1},
+		{"NewAttribute1", stdlen},
+	}
+	for _, tc := range tcs {
+		if ind := cfg.provideIndex(tc.name); ind != tc.ind {
+			t.Errorf("Incorrect mapping for %q: expected %d, got %d", tc.name, tc.ind, ind)
+		}
+	}
+}
+
+func TestParseAttrArg(t *testing.T) {
+	tcs := []struct {
+		input  string
+		name   string
+		stype  string
+		svalue string
+		err    bool
+	}{
+		{"attr1", "attr1", "Undefined", "", false},
+		{"attr2=`strVal1`", "attr2", "String", "strVal1", false},
+		{"attr3=\"strVal2\"", "attr3", "String", "strVal2", false},
+		{"attr4=strVal3", "", "Undefined", "", true}, // quotes are obligatory for strings
+		{"attr5=127.0.0.1", "attr5", "Address", "127.0.0.1", false},
+		{"attr6=1245:abcd::77fe", "attr6", "Address", "1245:abcd::77fe", false},
+		{"attr7=::baba:77fe", "attr7", "Address", "::baba:77fe", false},
+		{"attr8=:baba::77fe", "", "Undefined", "", true},
+		{"attr9=123456789123456789", "attr9", "Integer", "123456789123456789", false},
+		{"attrA=0x2694", "attrA", "Integer", "9876", false},
+		{"attrB=02322", "attrB", "Integer", "1234", false},
+		{"attrC=568word", "", "Undefined", "", true},
+		{"attrD=568.321", "", "Undefined", "", true}, //float is not supported for now
+		{"attrE=-333", "attrE", "Integer", "-333", false},
+		{"attrF=`str\"Val1\"`", "attrF", "String", "str\"Val1\"", false},
+	}
+	for i, tc := range tcs {
+		n, v, e := parseAttrArg(tc.input)
+		if (e != nil) != tc.err {
+			t.Errorf("TC#%d: incorrect error status", i)
+			continue
+		}
+		if n != tc.name {
+			t.Errorf("TC#%d: incorrect name: expected %s, got %s", i, tc.name, n)
+		}
+		vt := v.GetResultType().String()
+		if vt != tc.stype {
+			t.Errorf("TC#%d: incorrect type: expected %s, got %s", i, tc.stype, vt)
+		}
+		if vt == "Undefined" {
+			continue
+		}
+		vs, _ := v.Serialize()
+		if vs != tc.svalue {
+			t.Errorf("TC#%d: incorrect value: expected %s, got %s", i, tc.svalue, vs)
+		}
+	}
+}
+
+func TestParseAttrList(t *testing.T) {
+	cfg := newAttrsConfig()
+	stdlen := len(cfg.attrInds)
+
+	// incorrect input
+	err := cfg.parseAttrList(attrListTypeDefDecision, "incorrect=input")
+	if err == nil {
+		t.Errorf("Unexpected successful call")
+	}
+	if len(cfg.confLists[attrListTypeDefDecision]) != 0 {
+		t.Errorf("Config list is not empty")
 	}
 
-	if !custAttr(custAttrTransfer).isTransfer() {
-		t.Errorf("expected %d is transfer", custAttrTransfer)
+	// correct input
+	err = cfg.parseAttrList(attrListTypeDefDecision, "correct=123", attrNameLog)
+	if err != nil {
+		t.Errorf("Unexpected failed call")
+	}
+	exp := 2
+	if l := len(cfg.confLists[attrListTypeDefDecision]); l != exp {
+		t.Errorf("Unexpected size of config list; expected %d, got %d", exp, l)
+	}
+	for i, expInd := range []int{stdlen, attrIndexLog} {
+		if ind := cfg.confLists[attrListTypeDefDecision][i].index; ind != expInd {
+			t.Errorf("Unexpected index in config list; expected %d, got %d", expInd, ind)
+		}
 	}
 
-	if !custAttr(custAttrDnstap).isDnstap() {
-		t.Errorf("expected %d is DNStap", custAttrDnstap)
-	}
+	// incorrect list id
+	testutil.AssertPanicWithErrorContains(t, "serializeOrPanic(expression)", func() {
+		cfg.parseAttrList(10000, "incorrect_list_id")
+	}, "index out of range")
 }

--- a/contrib/coredns/policy/benchmark_test.go
+++ b/contrib/coredns/policy/benchmark_test.go
@@ -243,10 +243,17 @@ func benchParallelHalfHits(b *testing.B, p *policyPlugin, ps *parStat) {
 }
 
 const allPermitTestPolicy = `# All Permit Policy
+attributes:
+  policy_action: integer
 policies:
   alg: FirstApplicableEffect
   rules:
   - effect: Permit
+    obligations:
+    - policy_action:
+        val:
+          type: integer
+          content: 2
 `
 
 func newTestPolicyPlugin(mpMode int, endpoints ...string) *policyPlugin {
@@ -255,6 +262,9 @@ func newTestPolicyPlugin(mpMode int, endpoints ...string) *policyPlugin {
 	p.conf.connTimeout = time.Second
 	p.conf.streams = 1
 	p.conf.maxReqSize = 256
+	p.conf.autoResAttrs = true
+	p.conf.attrs.parseAttrList(attrListTypeVal1, attrNameDomainName)
+	p.conf.attrs.parseAttrList(attrListTypeVal2, attrNameAddress)
 
 	mp := &testutil.MockPlugin{
 		Ip: net.ParseIP("192.0.2.53"),

--- a/contrib/coredns/policy/client_test.go
+++ b/contrib/coredns/policy/client_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -9,7 +8,6 @@ import (
 	"github.com/infobloxopen/themis/contrib/coredns/policy/testutil"
 	"github.com/infobloxopen/themis/pdp"
 	_ "github.com/infobloxopen/themis/pdp/selector"
-	"github.com/miekg/dns"
 )
 
 const testPolicy = `# Policy set for client interaction tests
@@ -130,43 +128,29 @@ func TestStreamingClientInteraction(t *testing.T) {
 		}
 		defer p.closeConn()
 
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
-		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
-
-		ah := newAttrHolderWithDnReq(w, m, p.conf.options, nil)
-		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
-		if err := p.validate(ah, attrs); err != nil {
-			t.Error(err)
+		req := []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment("type", "query"),
+			pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeDnOrFail(t, "example.com")),
 		}
-
-		if ah.action != actionAllow {
-			aName := fmt.Sprintf("unknown action %d", ah.action)
-			if ah.action >= 0 && int(ah.action) < len(actionNames) {
-				aName = actionNames[ah.action]
-			}
-			t.Errorf("expected %q action but got %q", actionNames[actionAllow], aName)
+		res := pdp.Response{}
+		err := p.pdp.Validate(req, &res)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
 		}
-
-		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+		testutil.AssertPdpResponse(t, &res, pdp.EffectPermit,
 			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
 		)
 
-		ah.addIPReq(net.ParseIP("192.0.2.1"))
-
-		attrs = make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
-		if err := p.validate(ah, attrs); err != nil {
-			t.Error(err)
+		req = []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment("type", "response"),
+			pdp.MakeAddressAssignment(attrNameAddress, net.ParseIP("192.0.2.1")),
 		}
-
-		if ah.action != actionLog {
-			aName := fmt.Sprintf("unknown action %d", ah.action)
-			if ah.action >= 0 && int(ah.action) < len(actionNames) {
-				aName = actionNames[ah.action]
-			}
-			t.Errorf("expected %q action but got %q", actionNames[actionLog], aName)
+		res = pdp.Response{}
+		err = p.pdp.Validate(req, &res)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
 		}
-
-		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.ipRes,
+		testutil.AssertPdpResponse(t, &res, pdp.EffectPermit,
 			pdp.MakeStringAssignment("rule", "Response rule for 192.0.2.0/28"),
 			pdp.MakeStringAssignment("log", ""),
 		)
@@ -192,24 +176,16 @@ func TestStreamingClientInteraction(t *testing.T) {
 		}
 		defer p.closeConn()
 
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
-		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
-
-		ah := newAttrHolderWithDnReq(w, m, p.conf.options, nil)
-		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
-		if err := p.validate(ah, attrs); err != nil {
-			t.Error(err)
+		req := []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment("type", "query"),
+			pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeDnOrFail(t, "example.com")),
 		}
-
-		if ah.action != actionAllow {
-			aName := fmt.Sprintf("unknown action %d", ah.action)
-			if ah.action >= 0 && int(ah.action) < len(actionNames) {
-				aName = actionNames[ah.action]
-			}
-			t.Errorf("expected %q action but got %q", actionNames[actionAllow], aName)
+		res := pdp.Response{}
+		err := p.pdp.Validate(req, &res)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
 		}
-
-		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+		testutil.AssertPdpResponse(t, &res, pdp.EffectPermit,
 			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
 		)
 	})
@@ -235,24 +211,16 @@ func TestStreamingClientInteraction(t *testing.T) {
 		}
 		defer p.closeConn()
 
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
-		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
-
-		ah := newAttrHolderWithDnReq(w, m, p.conf.options, nil)
-		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
-		if err := p.validate(ah, attrs); err != nil {
-			t.Error(err)
+		req := []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment("type", "query"),
+			pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeDnOrFail(t, "example.com")),
 		}
-
-		if ah.action != actionAllow {
-			aName := fmt.Sprintf("unknown action %d", ah.action)
-			if ah.action >= 0 && int(ah.action) < len(actionNames) {
-				aName = actionNames[ah.action]
-			}
-			t.Errorf("expected %q action but got %q", actionNames[actionAllow], aName)
+		res := pdp.Response{}
+		err := p.pdp.Validate(req, &res)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
 		}
-
-		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+		testutil.AssertPdpResponse(t, &res, pdp.EffectPermit,
 			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
 		)
 	})
@@ -298,19 +266,14 @@ func TestStreamingClientInteractionWithObligationsOverflow(t *testing.T) {
 	}
 	defer p.closeConn()
 
-	m := testutil.MakeTestDNSMsg("overflow.me", dns.TypeA, dns.ClassINET)
-	w := testutil.NewTestAddressedNonwriter("192.0.2.1")
-
-	ah := newAttrHolderWithDnReq(w, m, p.conf.options, nil)
-	attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
-	err := p.validate(ah, attrs)
+	req := []pdp.AttributeAssignment{
+		pdp.MakeStringAssignment("type", "query"),
+		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeDnOrFail(t, "overflow.me")),
+	}
+	res := pdp.Response{Obligations: make([]pdp.AttributeAssignment, 1)}
+	err := p.pdp.Validate(req, &res)
 	if err == nil {
-		aName := fmt.Sprintf("unknown action %d", ah.action)
-		if ah.action >= 0 && int(ah.action) < len(actionNames) {
-			aName = actionNames[ah.action]
-		}
-
-		t.Errorf("expected response overflow error but got %q response:\n:%+v", aName, ah.dnRes)
+		t.Errorf("expected response overflow error but got response:\n:%+v", res)
 		ok = false
 	}
 }

--- a/contrib/coredns/policy/debug.go
+++ b/contrib/coredns/policy/debug.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/infobloxopen/themis/pdp"
@@ -19,7 +20,7 @@ func init() {
 }
 
 type dbgMessenger struct {
-	strings.Builder
+	bytes.Buffer
 	suffix string
 }
 

--- a/contrib/coredns/policy/debug_test.go
+++ b/contrib/coredns/policy/debug_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -14,8 +15,8 @@ func TestPatchDebugMsg(t *testing.T) {
 	p.conf.debugSuffix = "debug.local."
 
 	m := testutil.MakeTestDNSMsg("example.com.debug.local", dns.TypeTXT, dns.ClassCHAOS)
-	patched := p.patchDebugMsg(m)
-	if !patched {
+	dbgMsgr := p.patchDebugMsg(m)
+	if dbgMsgr == nil {
 		t.Error("expected patched message")
 	}
 
@@ -27,8 +28,8 @@ func TestPatchDebugMsg(t *testing.T) {
 	)
 
 	m = new(dns.Msg)
-	patched = p.patchDebugMsg(m)
-	if patched {
+	dbgMsgr = p.patchDebugMsg(m)
+	if dbgMsgr != nil {
 		t.Error("expected NOT patched message")
 	}
 
@@ -38,8 +39,8 @@ func TestPatchDebugMsg(t *testing.T) {
 	)
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeTXT, dns.ClassCHAOS)
-	patched = p.patchDebugMsg(m)
-	if patched {
+	dbgMsgr = p.patchDebugMsg(m)
+	if dbgMsgr != nil {
 		t.Error("expected NOT patched message")
 	}
 
@@ -51,144 +52,386 @@ func TestPatchDebugMsg(t *testing.T) {
 	)
 }
 
+func TestNewDbgMessenger(t *testing.T) {
+	dm := newDbgMessenger("suf", "id")
+	if dm.suffix != "suf" {
+		t.Errorf("Unexpected suffix: %s", dm.suffix)
+	}
+	if dm.String() != "Ident: id, " {
+		t.Errorf("Unexpected init message: %s", dm.String())
+	}
+
+	dm = newDbgMessenger("suff", "")
+	if dm.suffix != "suff" {
+		t.Errorf("Unexpected suffix: %s", dm.suffix)
+	}
+	if dm.String() != "" {
+		t.Errorf("Unexpected init message: %s", dm.String())
+	}
+}
+
+func TestDebugNameVal(t *testing.T) {
+	n, v := debugNameVal(pdp.MakeStringAssignment("attr1", "value1"))
+	if n != "attr1" || v != "value1" {
+		t.Errorf("Unexpected result: name=%s, val=%s", n, v)
+	}
+
+	n, v = debugNameVal(pdp.MakeIntegerAssignment("attr2", 12345))
+	if n != "attr2" || v != "12345" {
+		t.Errorf("Unexpected result: name=%s, val=%s", n, v)
+	}
+
+	n, v = debugNameVal(pdp.MakeAddressAssignment("attr3", net.ParseIP("2001:db8::1")))
+	if n != "attr3" || v != "2001:db8::1" {
+		t.Errorf("Unexpected result: name=%s, val=%s", n, v)
+	}
+}
+
+func TestAppendAttrs(t *testing.T) {
+	dm := &dbgMessenger{suffix: "debug.local."}
+	dm.appendAttrs("attributes", []pdp.AttributeAssignment{
+		pdp.MakeStringAssignment("attr1", "value1"),
+		pdp.MakeIntegerAssignment("attr2", 12345),
+		pdp.MakeAddressAssignment("attr3", net.ParseIP("2001:db8::1")),
+	})
+	if dm.String() != "attributes: [attr1: value1, attr2: 12345, attr3: 2001:db8::1, ], " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+}
+
+func TestAppendPassthrough(t *testing.T) {
+	dm := &dbgMessenger{suffix: "debug.local."}
+	dm.appendPassthrough()
+	if dm.String() != "Passthrough: yes, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+}
+
+func TestAppendDebugID(t *testing.T) {
+	dm := &dbgMessenger{suffix: "debug.local."}
+	dm.appendDebugID("DeBuGiD")
+	if dm.String() != "Ident: DeBuGiD, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+}
+
+func TestAppendResolution(t *testing.T) {
+	dm := &dbgMessenger{suffix: "debug.local."}
+	dm.appendResolution(-1)
+	if dm.String() != "Domain resolution: skipped, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+
+	dm = &dbgMessenger{suffix: "debug.local."}
+	dm.appendResolution(dns.RcodeSuccess)
+	if dm.String() != "Domain resolution: resolved, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+
+	dm = &dbgMessenger{suffix: "debug.local."}
+	dm.appendResolution(dns.RcodeServerFailure)
+	if dm.String() != "Domain resolution: failed, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+
+	dm = &dbgMessenger{suffix: "debug.local."}
+	dm.appendResolution(dns.RcodeNameError)
+	if dm.String() != "Domain resolution: not resolved, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+}
+
+func TestAppendResponse(t *testing.T) {
+	dm := &dbgMessenger{suffix: "debug.local."}
+	r := pdp.Response{
+		Effect: pdp.EffectPermit,
+		Obligations: []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment("attr1", "value1"),
+			pdp.MakeIntegerAssignment("attr2", 12345),
+			pdp.MakeAddressAssignment("attr3", net.ParseIP("2001:db8::1")),
+		},
+	}
+	dm.appendResponse(&r)
+	if dm.String() != "PDP response {Effect: Permit, Obligations: [attr1: value1, attr2: 12345, attr3: 2001:db8::1, ], }, " {
+		t.Errorf("Unexpected result: %s", dm.String())
+	}
+}
+
 func TestSetDebugQueryPassthroughAnswer(t *testing.T) {
-	p := newPolicyPlugin()
-	p.conf.debugSuffix = "debug.local."
-
+	dm := &dbgMessenger{suffix: "debug.local."}
 	m := testutil.MakeTestDNSMsg("example.passthrough.local", dns.TypeA, dns.ClassINET)
-	w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	ah := newAttrHolderWithDnReq(w, m, nil, nil)
-
-	p.setDebugQueryPassthroughAnswer(ah, m)
+	dm.setDebugQueryPassthroughAnswer("example.passthrough.local.", m)
 	testutil.AssertDNSMessage(t, "setDebugQueryPassthroughAnswer", 0, m, 0,
 		";; opcode: QUERY, status: NOERROR, id: 0\n"+
 			";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 			";; QUESTION SECTION:\n"+
 			";example.passthrough.local.\tIN\t A\n\n"+
 			";; ANSWER SECTION:\n"+
-			"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"action:passthrough\"\n",
+			"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Passthrough: yes, \"\n",
 	)
 }
 
 func TestSetDebugQueryAnswer(t *testing.T) {
-	p := newPolicyPlugin()
-	p.conf.debugID = "<DEBUG>"
-	p.conf.debugSuffix = "debug.local."
-
 	t.Run("OnDomainResponse(RcodeSuccess)", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
 		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-		ah := newAttrHolderWithDnReq(w, m, nil, nil)
-		ah.addDnRes(&pdp.Response{
-			Effect: pdp.EffectDeny,
-			Obligations: []pdp.AttributeAssignment{
-				pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
-			},
-		}, nil)
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
-		p.setDebugQueryAnswer(ah, m, dns.RcodeSuccess)
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
+			pdp.MakeIntegerAssignment("policy_action", 4),
+		}
+		mpc.Effect = pdp.EffectPermit
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t"+
-				"\"resolve:yes,query:'redirect',redirect_to:'192.0.2.54',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [redirect_to: 192.0.2.54, policy_action: redirect, ], }, "+
+				"Domain resolution: resolved, \"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(RcodeNameError)", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
 		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-		ah := newAttrHolderWithDnReq(w, m, nil, nil)
-		ah.addDnRes(&pdp.Response{
-			Effect: pdp.EffectPermit,
-		}, nil)
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
-		p.setDebugQueryAnswer(ah, m, dns.RcodeNameError)
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeIntegerAssignment("policy_action", 2),
+		}
+		mpc.Effect = pdp.EffectPermit
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeNameError)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t"+
-				"\"resolve:no,query:'allow',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"Domain resolution: not resolved, \"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(RcodeServerFailure)", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
 		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-		ah := newAttrHolderWithDnReq(w, m, nil, nil)
-		ah.addDnRes(&pdp.Response{
-			Effect: pdp.EffectPermit,
-		}, nil)
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
-		p.setDebugQueryAnswer(ah, m, dns.RcodeServerFailure)
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeIntegerAssignment("policy_action", 2),
+		}
+		mpc.Effect = pdp.EffectPermit
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeServerFailure)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t"+
-				"\"resolve:failed,query:'allow',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"Domain resolution: failed, \"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(-1)", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
 		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-		ah := newAttrHolderWithDnReq(w, m, nil, nil)
-		ah.addDnRes(&pdp.Response{
-			Effect: pdp.EffectPermit,
-		}, nil)
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
-		p.setDebugQueryAnswer(ah, m, -1)
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeIntegerAssignment("policy_action", 2),
+		}
+		mpc.Effect = pdp.EffectPermit
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, -1)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t"+
-				"\"resolve:skip,query:'allow',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"Domain resolution: skipped, \"\n",
 		)
 	})
 
 	t.Run("OnIPResponse", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
 		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-		ah := newAttrHolderWithDnReq(w, m, nil, nil)
-		ah.addDnRes(&pdp.Response{
-			Effect: pdp.EffectPermit,
-		}, nil)
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
+		cfg.attrs.parseAttrList(attrListTypeVal2, "address")
 
-		ah.addIPReq(net.ParseIP("192.0.2.53"))
-		ah.addIPRes(&pdp.Response{
-			Effect: pdp.EffectDeny,
-			Obligations: []pdp.AttributeAssignment{
-				pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
-			},
-		})
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeIntegerAssignment("policy_action", 2),
+		}
+		mpc.Effect = pdp.EffectPermit
 
-		p.setDebugQueryAnswer(ah, m, dns.RcodeSuccess)
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		ah.addAddressAttr(net.ParseIP("2001:db8::1"))
+		mpc.Out = []pdp.AttributeAssignment{
+			pdp.MakeIntegerAssignment("policy_action", 4),
+			pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
+		}
+
+		p.validate(nil, ah, attrListTypeVal2, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t"+
-				"\"resolve:yes,query:'pass',response:'redirect',redirect_to:'192.0.2.54',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: redirect, redirect_to: 192.0.2.54, ], }, "+
+				"Domain resolution: resolved, \"\n",
+		)
+	})
+
+	t.Run("DefaultDecisionOnError", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
+		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
+		cfg.attrs.parseAttrList(attrListTypeDefDecision, "policy_action=2")
+
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Err = fmt.Errorf("test PDP error")
+		mpc.Effect = pdp.EffectPermit
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
+			";; opcode: QUERY, status: NOERROR, id: 0\n"+
+				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
+				";; QUESTION SECTION:\n"+
+				";example.com.\tIN\t A\n\n"+
+				";; ANSWER SECTION:\n"+
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"Default decision: [policy_action: allow, ], "+
+				"Domain resolution: resolved, \"\n",
+		)
+	})
+
+	t.Run("DefaultDecisionOnEffectIndeterminate", func(t *testing.T) {
+		p := newPolicyPlugin()
+
+		mpc := testutil.NewMockPdpClient(t)
+		p.pdp = mpc
+
+		dm := newDbgMessenger("debug.local.", "<DEBUG>")
+
+		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+
+		cfg := newConfig()
+		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
+		cfg.attrs.parseAttrList(attrListTypeDefDecision, "policy_action=2")
+
+		ah := newAttrHolder(nil, cfg.attrs)
+		dn := ah.addDnsQuery(w, m, cfg.options)
+		mpc.Status = fmt.Errorf("test PDP error")
+		mpc.Effect = pdp.EffectIndeterminate
+
+		p.validate(nil, ah, attrListTypeVal1, dm)
+
+		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
+			";; opcode: QUERY, status: NOERROR, id: 0\n"+
+				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
+				";; QUESTION SECTION:\n"+
+				";example.com.\tIN\t A\n\n"+
+				";; ANSWER SECTION:\n"+
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Indeterminate, Obligations: [], }, "+
+				"Default decision: [policy_action: allow, ], "+
+				"Domain resolution: resolved, \"\n",
 		)
 	})
 }

--- a/contrib/coredns/policy/dnstap.go
+++ b/contrib/coredns/policy/dnstap.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap"
@@ -16,20 +15,8 @@ import (
 	"github.com/infobloxopen/themis/pdp"
 )
 
-var dnstapActionValues [actionsTotal]string
-
 type dnstapSender interface {
-	sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder)
-}
-
-func init() {
-	dnstapActionValues[actionInvalid] = strconv.Itoa(int(pb.PolicyAction_INVALID))
-	dnstapActionValues[actionRefuse] = strconv.Itoa(int(pb.PolicyAction_REFUSE))
-	dnstapActionValues[actionAllow] = strconv.Itoa(int(pb.PolicyAction_PASSTHROUGH))
-	dnstapActionValues[actionRedirect] = strconv.Itoa(int(pb.PolicyAction_REDIRECT))
-	dnstapActionValues[actionBlock] = strconv.Itoa(int(pb.PolicyAction_NXDOMAIN))
-	dnstapActionValues[actionLog] = strconv.Itoa(int(pb.PolicyAction_PASSTHROUGH))
-	dnstapActionValues[actionDrop] = strconv.Itoa(int(pb.PolicyAction_DENY))
+	sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, attrs []*pb.DnstapAttribute)
 }
 
 type policyDnstapSender struct {
@@ -43,7 +30,7 @@ func newPolicyDnstapSender(io dnstap.IORoutine) dnstapSender {
 // sendCRExtraMsg creates Client Response (CR) dnstap Message and writes an array
 // of extra attributes to Dnstap.Extra field. Then it asynchronously sends the
 // message with IORoutine interface
-func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, ah *attrHolder) {
+func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, attrs []*pb.DnstapAttribute) {
 	if w == nil || msg == nil {
 		log.Errorf("Failed to create dnstap CR message - no DNS response message found")
 		return
@@ -63,8 +50,8 @@ func (s *policyDnstapSender) sendCRExtraMsg(w dns.ResponseWriter, msg *dns.Msg, 
 	t := tap.Dnstap_MESSAGE
 
 	var extra []byte
-	if ah != nil {
-		extra, err = proto.Marshal(&pb.Extra{Attrs: ah.makeDnstapReport()})
+	if len(attrs) > 0 {
+		extra, err = proto.Marshal(&pb.Extra{Attrs: attrs})
 		if err != nil {
 			log.Errorf("Failed to create extra data for dnstap CR message (%v)", err)
 		}
@@ -87,32 +74,4 @@ func newDnstapAttribute(a pdp.AttributeAssignment) *pb.DnstapAttribute {
 		Id:    a.GetID(),
 		Value: serializeOrPanic(a),
 	}
-}
-
-func newDnstapAttributeFromAction(a byte) *pb.DnstapAttribute {
-	return &pb.DnstapAttribute{
-		Id:    attrNamePolicyAction,
-		Value: dnstapActionValues[a],
-	}
-}
-
-func newDnstapAttributeFromReqType(ipReq bool) *pb.DnstapAttribute {
-	out := &pb.DnstapAttribute{
-		Id:    attrNameType,
-		Value: typeValueQuery,
-	}
-
-	if ipReq {
-		out.Value = typeValueResponse
-	}
-
-	return out
-}
-
-func putAttrsToDnstap(attrs []pdp.AttributeAssignment, out []*pb.DnstapAttribute) int {
-	for i, a := range attrs {
-		out[i] = newDnstapAttribute(a)
-	}
-
-	return len(attrs)
 }

--- a/contrib/coredns/policy/dnstap_test.go
+++ b/contrib/coredns/policy/dnstap_test.go
@@ -101,9 +101,9 @@ func TestSendCRExtraMsg(t *testing.T) {
 	tapIO := newPolicyDnstapSender(io)
 
 	dnstapAttrs := []*pb.DnstapAttribute{
-		&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.0.0.7"},
-		&pb.DnstapAttribute{Id: "option", Value: "option"},
-		&pb.DnstapAttribute{Id: "dnstap", Value: "val"},
+		{Id: attrNameSourceIP, Value: "10.0.0.7"},
+		{Id: "option", Value: "option"},
+		{Id: "dnstap", Value: "val"},
 	}
 
 	tapIO.sendCRExtraMsg(tapRW, &msg, dnstapAttrs)

--- a/contrib/coredns/policy/dnstap_test.go
+++ b/contrib/coredns/policy/dnstap_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"net"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/dnstap"
@@ -9,7 +8,6 @@ import (
 	dtest "github.com/coredns/coredns/plugin/dnstap/test"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/infobloxopen/themis/contrib/coredns/policy/testutil"
-	"github.com/infobloxopen/themis/pdp"
 	"github.com/miekg/dns"
 	"golang.org/x/net/context"
 
@@ -102,45 +100,19 @@ func TestSendCRExtraMsg(t *testing.T) {
 	io := testutil.NewIORoutine()
 	tapIO := newPolicyDnstapSender(io)
 
-	testAttrHolder := &attrHolder{
-		dnReq: []pdp.AttributeAssignment{
-			pdp.MakeStringAssignment(attrNameType, typeValueQuery),
-			pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain("test.com")),
-			pdp.MakeStringAssignment(attrNameDNSQtype, "1"),
-			pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("10.0.0.7")),
-			pdp.MakeStringAssignment("option", "option"),
-		},
-		dnstap: []pdp.AttributeAssignment{
-			pdp.MakeStringAssignment("dnstap", "val"),
-		},
-		action: actionAllow,
+	dnstapAttrs := []*pb.DnstapAttribute{
+		&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.0.0.7"},
+		&pb.DnstapAttribute{Id: "option", Value: "option"},
+		&pb.DnstapAttribute{Id: "dnstap", Value: "val"},
 	}
 
-	tapIO.sendCRExtraMsg(tapRW, &msg, testAttrHolder)
+	tapIO.sendCRExtraMsg(tapRW, &msg, dnstapAttrs)
 
 	ok = testutil.AssertCRExtraResult(t, "sendCRExtraMsg(actionAllow)", io, &msg,
 		&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.0.0.7"},
 		&pb.DnstapAttribute{Id: "option", Value: "option"},
 		&pb.DnstapAttribute{Id: "dnstap", Value: "val"},
 	)
-
-	if l := len(trapper.Trap); l != 0 {
-		t.Fatalf("Dnstap unexpectedly sent %d messages", l)
-		ok = false
-	}
-
-	testAttrHolder.action = actionBlock
-
-	tapIO.sendCRExtraMsg(tapRW, &msg, testAttrHolder)
-
-	ok = testutil.AssertCRExtraResult(t, "sendCRExtraMsg(actionBlock)", io, &msg,
-		&pb.DnstapAttribute{Id: attrNameDomainName, Value: "test.com"},
-		&pb.DnstapAttribute{Id: attrNameDNSQtype, Value: "1"},
-		&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.0.0.7"},
-		&pb.DnstapAttribute{Id: "option", Value: "option"},
-		&pb.DnstapAttribute{Id: attrNamePolicyAction, Value: "3"},
-		&pb.DnstapAttribute{Id: attrNameType, Value: typeValueQuery},
-	) && ok
 
 	if l := len(trapper.Trap); l != 0 {
 		t.Fatalf("Dnstap unexpectedly sent %d messages", l)

--- a/contrib/coredns/policy/edns0.go
+++ b/contrib/coredns/policy/edns0.go
@@ -25,7 +25,7 @@ type edns0Opt struct {
 	size     int
 	start    int
 	end      int
-	metrics  bool
+	attrInd  int
 }
 
 func newEdns0Opt(sCode, name, sType, sSize, sStart, sEnd string) (uint16, *edns0Opt, error) {

--- a/contrib/coredns/policy/metrics.go
+++ b/contrib/coredns/policy/metrics.go
@@ -265,20 +265,8 @@ func unixTime() uint32 {
 // configures globalAttrGauge as needed
 func (pp *policyPlugin) SetupMetrics(c *caddy.Controller) error {
 	attrNames := []string{}
-	for attr, t := range pp.conf.custAttrs {
-		if !t.isMetrics() {
-			continue
-		}
-
-		attrNames = append(attrNames, attr)
-
-		for _, list := range pp.conf.options {
-			for _, opt := range list {
-				if opt.name == attr {
-					opt.metrics = true
-				}
-			}
-		}
+	for _, conf := range pp.conf.attrs.confLists[attrListTypeMetrics] {
+		attrNames = append(attrNames, conf.name)
 	}
 	if len(attrNames) > 0 {
 		if mh := dnsserver.GetConfig(c).Handler("prometheus"); mh != nil {

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -1,20 +1,16 @@
 package policy
 
 import (
-	"bytes"
 	"fmt"
 	"net"
-	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap/taprw"
 	dtest "github.com/coredns/coredns/plugin/dnstap/test"
 	"github.com/infobloxopen/themis/contrib/coredns/policy/testutil"
-	"github.com/infobloxopen/themis/pep"
+	"github.com/infobloxopen/themis/pdp"
 	"github.com/miekg/dns"
-	logr "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	pb "github.com/infobloxopen/themis/contrib/coredns/policy/dnstap"
@@ -34,6 +30,48 @@ func TestPolicyPluginName(t *testing.T) {
 	if n != "policy" {
 		t.Errorf("expected %q as plugin name but got %q", "policy", n)
 	}
+}
+
+func TestPolicyPluginValidate(t *testing.T) {
+	p := newPolicyPlugin()
+	p.conf.attrs.parseAttrList(attrListTypeVal1, `type="query"`, attrNameDomainName, attrNameSourceIP)
+
+	m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+	w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+
+	ah := newAttrHolder(nil, p.conf.attrs)
+	ah.addDnsQuery(w, m, p.conf.options)
+
+	mpc := testutil.NewMockPdpClient(t)
+	mpc.In = []pdp.AttributeAssignment{
+		pdp.MakeStringAssignment("type", "query"),
+		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
+	}
+	mpc.Out = []pdp.AttributeAssignment{
+		pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
+		pdp.MakeIntegerAssignment("policy_action", 4),
+	}
+	mpc.Effect = pdp.EffectPermit
+	p.pdp = mpc
+
+	goon, err := p.validate(nil, ah, attrListTypeVal1, nil)
+	if !goon {
+		t.Errorf("Unexpected result of validate(): expected true, but got %t", goon)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error of validate(): expected nil, but got %s", err)
+	}
+	testutil.AssertAttrList(t, ah.attrs,
+		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeStringAssignment(attrNameDNSQtype, "1"),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
+		emptyAttr,
+		pdp.MakeIntegerAssignment("policy_action", 4),
+		pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
+		emptyAttr,
+		pdp.MakeStringAssignment("type", "query"),
+	)
 }
 
 func TestPolicyPluginServeDNS(t *testing.T) {
@@ -56,14 +94,17 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	p.conf.log = true
 	p.conf.debugID = "<DEBUG>"
 	p.conf.debugSuffix = "debug.local."
+	p.conf.autoResAttrs = true
+	p.conf.attrs.parseAttrList(attrListTypeVal1, attrNameDomainName, `type="query"`)
+	p.conf.attrs.parseAttrList(attrListTypeVal2, attrNameAddress, `type="response"`)
 
-	mp := &mockPlugin{
-		ip: net.ParseIP("192.0.2.53"),
-		rc: dns.RcodeSuccess,
+	mp := &testutil.MockPlugin{
+		Ip: net.ParseIP("192.0.2.53"),
+		Rc: dns.RcodeSuccess,
 	}
 	p.next = mp
 
-	g := newLogGrabber()
+	g := testutil.NewLogGrabber()
 	if err := p.connect(); err != nil {
 		logs := g.Release()
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
@@ -74,14 +115,14 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err := p.ServeDNS(context.TODO(), w, m)
 	logs := g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -96,20 +137,23 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com.debug.local", dns.TypeTXT, dns.ClassCHAOS)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(debug)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(debug)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"resolve:yes,query:'allow',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"Domain resolution: resolved, \"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
@@ -118,14 +162,14 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.redirect", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(domain redirect)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(domain redirect)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -140,16 +184,16 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	mp.ip = net.ParseIP("192.0.2.1")
+	mp.Ip = net.ParseIP("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(address redirect)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(address redirect)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -161,19 +205,19 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 		}
 	}
 
-	mp.ip = net.ParseIP("192.0.2.53")
+	mp.Ip = net.ParseIP("192.0.2.53")
 
 	m = testutil.MakeTestDNSMsg("example.block", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(domain block)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(domain block)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NXDOMAIN, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -186,16 +230,16 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	mp.ip = net.ParseIP("192.0.2.17")
+	mp.Ip = net.ParseIP("192.0.2.17")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(address block)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(address block)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NXDOMAIN, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -205,19 +249,19 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 		}
 	}
 
-	mp.ip = net.ParseIP("192.0.2.53")
+	mp.Ip = net.ParseIP("192.0.2.53")
 
 	m = testutil.MakeTestDNSMsg("example.refuse", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(domain refuse)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(domain refuse)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: REFUSED, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -230,16 +274,16 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	mp.ip = net.ParseIP("192.0.2.33")
+	mp.Ip = net.ParseIP("192.0.2.33")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(address refuse)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(address refuse)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: REFUSED, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -249,19 +293,19 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 		}
 	}
 
-	mp.ip = net.ParseIP("192.0.2.53")
+	mp.Ip = net.ParseIP("192.0.2.53")
 
 	m = testutil.MakeTestDNSMsg("example.drop", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(domain drop)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(domain drop)", rc, w.Msg, dns.RcodeSuccess,
 			"<nil> MsgHdr",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
@@ -271,67 +315,67 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	mp.ip = net.ParseIP("192.0.2.65")
+	mp.Ip = net.ParseIP("192.0.2.65")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(address drop)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(address drop)", rc, w.Msg, dns.RcodeSuccess,
 			"<nil> MsgHdr",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
 	}
 
-	mp.ip = net.ParseIP("192.0.2.53")
+	mp.Ip = net.ParseIP("192.0.2.53")
 
 	m = testutil.MakeTestDNSMsg("example.missing", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err == nil {
 		t.Errorf("expected errInvalidAction but got rc: %d, msg:\n%q", rc, w.Msg)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else if err != errInvalidAction {
-		t.Errorf("exepcted errInvalidAction but got %T: %s", err, err)
+		t.Errorf("expected errInvalidAction but got %T: %s", err, err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	mp.ip = net.ParseIP("192.0.2.81")
+	mp.Ip = net.ParseIP("192.0.2.81")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err == nil {
 		t.Errorf("expected errInvalidAction but got rc: %d, msg:\n%q", rc, w.Msg)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else if err != errInvalidAction {
-		t.Errorf("exepcted errInvalidAction but got %T: %s", err, err)
+		t.Errorf("expected errInvalidAction but got %T: %s", err, err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
 
-	mp.err = fmt.Errorf("test next plugin error")
+	mp.Err = fmt.Errorf("test next plugin error")
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
-	if err != mp.err {
-		t.Errorf("expected %q but got %q", mp.err, err)
+	if err != mp.Err {
+		t.Errorf("expected %q but got %q", mp.Err, err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
-	if !assertDNSMessage(t, "ServeDNS(next plugin error)", rc, w.Msg, dns.RcodeSuccess,
+	if !testutil.AssertDNSMessage(t, "ServeDNS(next plugin error)", rc, w.Msg, dns.RcodeSuccess,
 		";; opcode: QUERY, status: SERVFAIL, id: 0\n"+
 			";; flags: qr; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 			";; QUESTION SECTION:\n;example.com.\tIN\t A\n",
@@ -342,59 +386,61 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.com.debug.local", dns.TypeTXT, dns.ClassCHAOS)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(next plugin error with debug)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(next plugin error with debug)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"resolve:failed,query:'allow',ident:'<DEBUG>'\"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
+				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
+				"Domain resolution: failed, \"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
 	}
 
-	mp.err = nil
-	mp.ip = nil
+	mp.Err = nil
+	mp.Ip = nil
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(dropped by resolver)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(dropped by resolver)", rc, w.Msg, dns.RcodeSuccess,
 			"<nil> MsgHdr",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
 	}
 
-	mp.ip = net.ParseIP("192.0.2.53")
-	mp.rc = dns.RcodeServerFailure
+	mp.Ip = net.ParseIP("192.0.2.53")
+	mp.Rc = dns.RcodeServerFailure
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(resolver failed)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(resolver failed)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: SERVFAIL, id: 0\n"+
 				";; flags: qr aa; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -404,45 +450,45 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 		}
 	}
 
-	mp.rc = dns.RcodeSuccess
+	mp.Rc = dns.RcodeSuccess
 
 	client := p.pdp
 
 	dnErr := fmt.Errorf("test error on domain validation")
-	errPep := newErraticPep(client, dnErr, nil)
+	errPep := testutil.NewErraticPep(client, dnErr, nil)
 	p.pdp = errPep
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != dnErr {
 		t.Errorf("expected %q but got %q", dnErr, err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
-	if !assertDNSMessage(t, "ServeDNS(error on domain validation)", rc, w.Msg, dns.RcodeSuccess,
+	if !testutil.AssertDNSMessage(t, "ServeDNS(error on domain validation)", rc, w.Msg, dns.RcodeSuccess,
 		"<nil> MsgHdr",
 	) {
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
 
 	ipErr := fmt.Errorf("test error on address validation")
-	errPep = newErraticPep(client, nil, ipErr)
+	errPep = testutil.NewErraticPep(client, nil, ipErr)
 	p.pdp = errPep
 
 	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != ipErr {
 		t.Errorf("expected %q but got %q", ipErr, err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	}
-	if !assertDNSMessage(t, "ServeDNS(error on domain validation)", rc, w.Msg, dns.RcodeSuccess,
+	if !testutil.AssertDNSMessage(t, "ServeDNS(error on domain validation)", rc, w.Msg, dns.RcodeSuccess,
 		"<nil> MsgHdr",
 	) {
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
@@ -465,12 +511,12 @@ func TestPolicyPluginServeDNSPassthrough(t *testing.T) {
 	p.conf.debugID = "<DEBUG>"
 	p.conf.debugSuffix = "debug.local."
 
-	p.next = &mockPlugin{
-		ip: net.ParseIP("192.0.2.53"),
-		rc: dns.RcodeSuccess,
+	p.next = &testutil.MockPlugin{
+		Ip: net.ParseIP("192.0.2.53"),
+		Rc: dns.RcodeSuccess,
 	}
 
-	g := newLogGrabber()
+	g := testutil.NewLogGrabber()
 	if err := p.connect(); err != nil {
 		logs := g.Release()
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
@@ -481,14 +527,14 @@ func TestPolicyPluginServeDNSPassthrough(t *testing.T) {
 	m := testutil.MakeTestDNSMsg("example.passthrough.local", dns.TypeA, dns.ClassINET)
 	w := testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err := p.ServeDNS(context.TODO(), w, m)
 	logs := g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(passthrough)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(passthrough)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -503,20 +549,20 @@ func TestPolicyPluginServeDNSPassthrough(t *testing.T) {
 	m = testutil.MakeTestDNSMsg("example.passthrough.local.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 	w = testutil.NewTestAddressedNonwriter("192.0.2.1")
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err = p.ServeDNS(context.TODO(), w, m)
 	logs = g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS(passthrough+debug)", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS(passthrough+debug)", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.passthrough.local.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"action:passthrough\"\n",
+				"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, Passthrough: yes, \"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
@@ -543,17 +589,24 @@ func TestPolicyPluginServeDNSWithDnstap(t *testing.T) {
 	p.conf.log = true
 	p.conf.debugID = "<DEBUG>"
 	p.conf.debugSuffix = "debug.local."
+	p.conf.autoResAttrs = true
+	p.conf.attrs.parseAttrList(attrListTypeVal1, attrNameDomainName, `type="query"`)
+	p.conf.attrs.parseAttrList(attrListTypeVal2, attrNameAddress, `type="response"`)
+	p.conf.attrs.parseAttrList(attrListTypeDnstap,
+		attrNameSourceIP, attrNamePolicyAction, attrNameRedirectTo)
+	p.conf.attrs.parseAttrList(attrListTypeDnstap+1,
+		attrNameDomainName, attrNamePolicyAction, attrNameRedirectTo)
 
-	mp := &mockPlugin{
-		ip: net.ParseIP("192.0.2.53"),
-		rc: dns.RcodeSuccess,
+	mp := &testutil.MockPlugin{
+		Ip: net.ParseIP("192.0.2.53"),
+		Rc: dns.RcodeSuccess,
 	}
 	p.next = mp
 
 	io := testutil.NewIORoutine()
 	p.tapIO = newPolicyDnstapSender(io)
 
-	g := newLogGrabber()
+	g := testutil.NewLogGrabber()
 	if err := p.connect(); err != nil {
 		logs := g.Release()
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
@@ -575,14 +628,14 @@ func TestPolicyPluginServeDNSWithDnstap(t *testing.T) {
 		Send:           &taprw.SendOption{Cq: false, Cr: false},
 	}
 
-	g = newLogGrabber()
+	g = testutil.NewLogGrabber()
 	rc, err := p.ServeDNS(context.TODO(), tapRW, m)
 	logs := g.Release()
 	if err != nil {
 		t.Error(err)
 		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 	} else {
-		if !assertDNSMessage(t, "ServeDNS", rc, w.Msg, dns.RcodeSuccess,
+		if !testutil.AssertDNSMessage(t, "ServeDNS", rc, w.Msg, dns.RcodeSuccess,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
@@ -595,6 +648,68 @@ func TestPolicyPluginServeDNSWithDnstap(t *testing.T) {
 
 		if !testutil.AssertCRExtraResult(t, "sendCRExtraMsg(actionAllow)", io, w.Msg,
 			&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.240.0.1"},
+			&pb.DnstapAttribute{Id: attrNamePolicyAction, Value: "2"},
+		) {
+			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+		}
+	}
+
+	m = testutil.MakeTestDNSMsg("example.log", dns.TypeA, dns.ClassINET)
+	w = testutil.NewTestAddressedNonwriterWithAddr(&net.UDPAddr{
+		IP:   net.ParseIP("10.240.0.1"),
+		Port: 40212,
+		Zone: "",
+	})
+
+	tapRW = &taprw.ResponseWriter{
+		Query:          new(dns.Msg),
+		ResponseWriter: w,
+		Tapper:         &dtest.TrapTapper{Full: true},
+		Send:           &taprw.SendOption{Cq: false, Cr: false},
+	}
+
+	g = testutil.NewLogGrabber()
+	rc, err = p.ServeDNS(context.TODO(), tapRW, m)
+	logs = g.Release()
+	if err != nil {
+		t.Error(err)
+		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+	} else {
+		if !testutil.AssertCRExtraResult(t, "sendCRExtraMsg(actionLog0)", io, w.Msg,
+			&pb.DnstapAttribute{Id: attrNameSourceIP, Value: "10.240.0.1"},
+			&pb.DnstapAttribute{Id: attrNamePolicyAction, Value: "4"},
+			&pb.DnstapAttribute{Id: attrNameRedirectTo, Value: "redir.ect"},
+		) {
+			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+		}
+	}
+
+	m = testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+	w = testutil.NewTestAddressedNonwriterWithAddr(&net.UDPAddr{
+		IP:   net.ParseIP("10.240.0.1"),
+		Port: 40212,
+		Zone: "",
+	})
+
+	tapRW = &taprw.ResponseWriter{
+		Query:          new(dns.Msg),
+		ResponseWriter: w,
+		Tapper:         &dtest.TrapTapper{Full: true},
+		Send:           &taprw.SendOption{Cq: false, Cr: false},
+	}
+
+	mp.Ip = net.ParseIP("192.0.2.97")
+
+	g = testutil.NewLogGrabber()
+	rc, err = p.ServeDNS(context.TODO(), tapRW, m)
+	logs = g.Release()
+	if err != nil {
+		t.Error(err)
+		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+	} else {
+		if !testutil.AssertCRExtraResult(t, "sendCRExtraMsg(actionLog1)", io, w.Msg,
+			&pb.DnstapAttribute{Id: attrNameDomainName, Value: "example.com."},
+			&pb.DnstapAttribute{Id: attrNamePolicyAction, Value: "3"},
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
@@ -607,8 +722,8 @@ attributes:
   domain_name: domain
   address: address
   redirect_to: string
-  refuse: string
-  drop: string
+  policy_action: integer
+  log: integer
   missing: string
 policies:
   alg: FirstApplicableEffect
@@ -631,6 +746,33 @@ policies:
             - example.com
         - attr: domain_name
       effect: Permit
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 2
+    - id: "Redirect example.log and log 0"
+      target:
+      - contains:
+        - val:
+            type: set of domains
+            content:
+            - example.log
+        - attr: domain_name
+      effect: Deny
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 4
+      - redirect_to:
+          val:
+            type: string
+            content: redir.ect
+      - log:
+          val:
+            type: integer
+            content: 0
     - id: "Redirect example.redirect"
       target:
       - contains:
@@ -641,6 +783,10 @@ policies:
         - attr: domain_name
       effect: Deny
       obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 4
       - redirect_to:
           val:
             type: string
@@ -654,6 +800,11 @@ policies:
             - example.block
         - attr: domain_name
       effect: Deny
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 3
     - id: "Refuse example.refuse"
       target:
       - contains:
@@ -664,10 +815,10 @@ policies:
         - attr: domain_name
       effect: Deny
       obligations:
-      - refuse:
+      - policy_action:
           val:
-            type: string
-            content: ""
+            type: integer
+            content: 5
     - id: "Drop example.drop"
       target:
       - contains:
@@ -678,10 +829,10 @@ policies:
         - attr: domain_name
       effect: Deny
       obligations:
-      - drop:
+      - policy_action:
           val:
-            type: string
-            content: ""
+            type: integer
+            content: 1
     - id: "Missing attribute example.missing"
       target:
       - contains:
@@ -715,6 +866,29 @@ policies:
             - 192.0.2.48/28
         - attr: address
       effect: Permit
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 2
+    - id: "Block 192.0.2.96/28 and log 1"
+      target:
+      - contains:
+        - val:
+            type: set of networks
+            content:
+            - 192.0.2.96/28
+        - attr: address
+      effect: Permit
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 3
+      - log:
+          val:
+            type: integer
+            content: 1
     - id: "Redirect 192.0.2.0/28"
       target:
       - contains:
@@ -725,6 +899,10 @@ policies:
         - attr: address
       effect: Deny
       obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 4
       - redirect_to:
           val:
             type: string
@@ -738,6 +916,11 @@ policies:
             - 192.0.2.16/28
         - attr: address
       effect: Deny
+      obligations:
+      - policy_action:
+          val:
+            type: integer
+            content: 3
     - id: "Refuse 192.0.2.32/28"
       target:
       - contains:
@@ -748,10 +931,10 @@ policies:
         - attr: address
       effect: Deny
       obligations:
-      - refuse:
+      - policy_action:
           val:
-            type: string
-            content: ""
+            type: integer
+            content: 5
     - id: "Drop 192.0.2.64/28"
       target:
       - contains:
@@ -762,10 +945,10 @@ policies:
         - attr: address
       effect: Deny
       obligations:
-      - drop:
+      - policy_action:
           val:
-            type: string
-            content: ""
+            type: integer
+            content: 1
     - id: "Missing attribute 192.0.2.80/28"
       target:
       - contains:
@@ -782,213 +965,3 @@ policies:
             content: missing
       effect: Permit
 `
-
-func assertDNSMessage(t *testing.T, desc string, rc int, m *dns.Msg, erc int, eMsg string) bool {
-	ok := true
-
-	if rc != erc {
-		t.Errorf("expected %d rcode for %q but got %d", erc, desc, rc)
-		ok = false
-	}
-
-	if m.String() != eMsg {
-		t.Errorf("expected response for %q:\n%q\nbut got:\n%q", desc, eMsg, m)
-		ok = false
-	}
-
-	return ok
-}
-
-type logGrabber struct {
-	b *bytes.Buffer
-}
-
-func newLogGrabber() *logGrabber {
-	b := new(bytes.Buffer)
-	logr.SetOutput(b)
-
-	return &logGrabber{
-		b: b,
-	}
-}
-
-func (g *logGrabber) Release() string {
-	logr.SetOutput(os.Stderr)
-
-	return g.b.String()
-}
-
-const (
-	mpModeConst = iota
-	mpModeInc
-	mpModeHalfInc
-)
-
-type mockPlugin struct {
-	ip   net.IP
-	err  error
-	rc   int
-	mode int
-	cnt  *uint32
-}
-
-// Name implements the plugin.Handler interface.
-func (p *mockPlugin) Name() string {
-	return "mockPlugin"
-}
-
-// ServeDNS implements the plugin.Handler interface.
-func (p *mockPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	if p.err != nil {
-		return dns.RcodeServerFailure, p.err
-	}
-
-	if r == nil || len(r.Question) <= 0 {
-		return dns.RcodeServerFailure, nil
-	}
-
-	ip := p.ip
-	if p.mode != mpModeConst && p.cnt != nil {
-		i := atomic.AddUint32(p.cnt, 1)
-
-		if p.mode != mpModeHalfInc || i&1 == 0 {
-			ip = addToIP(ip, i)
-		}
-	}
-
-	q := r.Question[0]
-	hdr := dns.RR_Header{
-		Name:   q.Name,
-		Rrtype: q.Qtype,
-		Class:  q.Qclass,
-	}
-
-	if ipv4 := ip.To4(); ipv4 != nil {
-		if q.Qtype != dns.TypeA {
-			return dns.RcodeSuccess, nil
-		}
-
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Authoritative = true
-		m.Rcode = p.rc
-
-		if m.Rcode == dns.RcodeSuccess {
-			m.Answer = append(m.Answer,
-				&dns.A{
-					Hdr: hdr,
-					A:   ipv4,
-				},
-			)
-		}
-
-		w.WriteMsg(m)
-	} else if ipv6 := ip.To16(); ipv6 != nil {
-		if q.Qtype != dns.TypeAAAA {
-			return dns.RcodeSuccess, nil
-		}
-
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Authoritative = true
-		m.Rcode = p.rc
-
-		if m.Rcode == dns.RcodeSuccess {
-			m.Answer = append(m.Answer,
-				&dns.AAAA{
-					Hdr:  hdr,
-					AAAA: ipv6,
-				},
-			)
-		}
-
-		w.WriteMsg(m)
-	}
-
-	return p.rc, nil
-}
-
-func addToIP(ip net.IP, n uint32) net.IP {
-	if n == 0 {
-		return ip
-	}
-
-	out := net.IP(make([]byte, len(ip)))
-	copy(out, ip)
-
-	d := uint(n % 256)
-	n /= 256
-
-	c := uint(n % 256)
-	n /= 256
-
-	b := uint(n % 256)
-	n /= 256
-
-	a := uint(n)
-
-	t := uint(out[len(out)-1])
-	t += d
-	out[len(out)-1] = byte(t % 256)
-
-	z := uint(out[len(out)-2])
-	if t > 255 {
-		z++
-	}
-
-	z += c
-	out[len(out)-2] = byte(z % 256)
-
-	y := uint(out[len(out)-3])
-	if z > 255 {
-		y++
-	}
-
-	y += b
-	out[len(out)-3] = byte(y % 256)
-
-	x := uint(out[len(out)-4])
-	if y > 255 {
-		x++
-	}
-
-	x += a
-	out[len(out)-4] = byte(x % 256)
-
-	return out
-}
-
-type erraticPep struct {
-	counter int
-	err     []error
-	client  pep.Client
-}
-
-func newErraticPep(c pep.Client, err ...error) *erraticPep {
-	return &erraticPep{
-		err:    err,
-		client: c,
-	}
-}
-
-func (c *erraticPep) Connect(addr string) error {
-	return c.client.Connect(addr)
-}
-
-func (c *erraticPep) Close() {
-	c.client.Close()
-}
-
-func (c *erraticPep) Validate(in, out interface{}) error {
-	if len(c.err) > 0 {
-		n := c.counter % len(c.err)
-		c.counter++
-
-		err := c.err[n]
-		if err != nil {
-			return err
-		}
-	}
-
-	return c.client.Validate(in, out)
-}

--- a/contrib/coredns/policy/pool.go
+++ b/contrib/coredns/policy/pool.go
@@ -24,6 +24,14 @@ func makeAttrPool(size int, dummy bool) attrPool {
 	return p
 }
 
+func createAttrPoolFromConfig(conf *config) attrPool {
+	size := len(conf.attrs.attrInds)
+	if conf.maxResAttrs > size {
+		size = conf.maxResAttrs
+	}
+	return makeAttrPool(size, false)
+}
+
 func (p attrPool) newAttrs() []pdp.AttributeAssignment {
 	return make([]pdp.AttributeAssignment, p.s)
 }


### PR DESCRIPTION
 - added/modified attribute configuration in corefile. Affected options
   are validation1, validation2, default_decision, metrics, dnstap. See
   more details in README.md

 - fallback to default decision in case if PDP validation failed.

 - refactored debug query

 - added integer "policy_action" attribute which contains explicit
   action, i.e. now action is not deduced from existence and/or content of
   other attributes. Removed attributes "refuse" and "drop"

 - attribute "log" now defines the dnstap log level, i.e. the set of
   attributes to be sent with dnstap message