### PR TITLE
policy plugin: reset TTL on Log action to prevent caching

### DIFF
--- a/contrib/coredns/policy/dns.go
+++ b/contrib/coredns/policy/dns.go
@@ -102,10 +102,10 @@ func resetTTL(r *dns.Msg) *dns.Msg {
 	}
 
 	for _, rr := range r.Answer {
-		// Ttl field in OPT record has different meaning
-		if _, ok := rr.(*dns.OPT); !ok {
-			rr.Header().Ttl = 0
-		}
+		rr.Header().Ttl = 0
+	}
+	for _, rr := range r.Ns {
+		rr.Header().Ttl = 0
 	}
 
 	return r


### PR DESCRIPTION
 - reset TTLs of AUTHORITY RRs as well, since NXDOMAIN responses
   may not have records in ANSWER section

 - removed check for OPT RR, since according to rfc6891 OPT RR should
   appear in ADDITIONAL (Extra) section