### PR TITLE
policy plugin: split long TXT records

### DIFF
--- a/contrib/coredns/policy/client.go
+++ b/contrib/coredns/policy/client.go
@@ -105,7 +105,7 @@ func (p *policyPlugin) validate(buf []pdp.AttributeAssignment, ah *attrHolder, l
 	if err != nil {
 		log.Errorf("Policy validation failed due to error: %s", err)
 		if dbg != nil {
-			dbg.appendAttrs("Default decision", ah.attrList(buf, attrListTypeDefDecision))
+			dbg.appendDefaultDecision(ah.attrList(buf, attrListTypeDefDecision))
 		} else {
 			ah.resetAttrList(attrListTypeDefDecision)
 		}
@@ -122,7 +122,7 @@ func (p *policyPlugin) validate(buf []pdp.AttributeAssignment, ah *attrHolder, l
 	if res.Effect != pdp.EffectPermit && res.Effect != pdp.EffectDeny {
 		log.Errorf("Policy validation failed due to PDP error: %s", res.Status)
 		if dbg != nil {
-			dbg.appendAttrs("Default decision", ah.attrList(buf, attrListTypeDefDecision))
+			dbg.appendDefaultDecision(ah.attrList(buf, attrListTypeDefDecision))
 		} else {
 			ah.resetAttrList(attrListTypeDefDecision)
 		}

--- a/contrib/coredns/policy/debug_test.go
+++ b/contrib/coredns/policy/debug_test.go
@@ -53,20 +53,52 @@ func TestPatchDebugMsg(t *testing.T) {
 }
 
 func TestNewDbgMessenger(t *testing.T) {
-	dm := newDbgMessenger("suf", "id")
-	if dm.suffix != "suf" {
-		t.Errorf("Unexpected suffix: %s", dm.suffix)
+	dm := newDbgMessenger(testOrgName, "id")
+	if dm.orgName != testOrgName {
+		t.Errorf("Unexpected original name: %s", dm.orgName)
 	}
-	if dm.String() != "Ident: id, " {
+	if dm.String() != "Ident: id" {
 		t.Errorf("Unexpected init message: %s", dm.String())
 	}
 
-	dm = newDbgMessenger("suff", "")
-	if dm.suffix != "suff" {
-		t.Errorf("Unexpected suffix: %s", dm.suffix)
+	dm = newDbgMessenger(testOrgName, "")
+	if dm.orgName != testOrgName {
+		t.Errorf("Unexpected original name: %s", dm.orgName)
 	}
 	if dm.String() != "" {
 		t.Errorf("Unexpected init message: %s", dm.String())
+	}
+}
+
+func TestTxtMsgs(t *testing.T) {
+	dm := newTestDbgMessenger()
+	dm.WriteString("extremely long string, 25extremely long string, 50")
+	dm.WriteString("extremely long string, 75extremely long string,100")
+	dm.WriteString("extremely long string,125extremely long string,150")
+	dm.WriteString("extremely long string,175extremely long string,200")
+	dm.WriteString("extremely long string,225extremely long string,250")
+	dm.WriteString("extremely long string,275extremely long string,300")
+	dm.msgBounds = []int{7, 296, 300}
+
+	txts := dm.txtMsgs()
+	if len(txts) != 4 {
+		t.Errorf("Unexpected number of TXT messages: %q", txts)
+		return
+	}
+	for i, exp := range []string{
+		"extreme",
+		"ly long string, 25extremely long string, 50" +
+			"extremely long string, 75extremely long string,100" +
+			"extremely long string,125extremely long string,150" +
+			"extremely long string,175extremely long string,200" +
+			"extremely long string,225extremely long string,250" +
+			"extremely lo",
+		"ng string,275extremely long string",
+		",300",
+	} {
+		if txts[i] != exp {
+			t.Errorf("Unexpected TXT #%d: expected %q, actual %q", i, exp, txts[i])
+		}
 	}
 }
 
@@ -88,61 +120,61 @@ func TestDebugNameVal(t *testing.T) {
 }
 
 func TestAppendAttrs(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newTestDbgMessenger()
 	dm.appendAttrs("attributes", []pdp.AttributeAssignment{
 		pdp.MakeStringAssignment("attr1", "value1"),
 		pdp.MakeIntegerAssignment("attr2", 12345),
 		pdp.MakeAddressAssignment("attr3", net.ParseIP("2001:db8::1")),
 	})
-	if dm.String() != "attributes: [attr1: value1, attr2: 12345, attr3: 2001:db8::1, ], " {
+	if dm.String() != "attributes: [attr1: value1, attr2: 12345, attr3: 2001:db8::1]" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 }
 
 func TestAppendPassthrough(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newTestDbgMessenger()
 	dm.appendPassthrough()
-	if dm.String() != "Passthrough: yes, " {
+	if dm.String() != "Passthrough: yes" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 }
 
 func TestAppendDebugID(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newTestDbgMessenger()
 	dm.appendDebugID("DeBuGiD")
-	if dm.String() != "Ident: DeBuGiD, " {
+	if dm.String() != "Ident: DeBuGiD" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 }
 
 func TestAppendResolution(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newTestDbgMessenger()
 	dm.appendResolution(-1)
-	if dm.String() != "Domain resolution: skipped, " {
+	if dm.String() != "Domain resolution: skipped" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 
-	dm = &dbgMessenger{suffix: "debug.local."}
+	dm = newTestDbgMessenger()
 	dm.appendResolution(dns.RcodeSuccess)
-	if dm.String() != "Domain resolution: resolved, " {
+	if dm.String() != "Domain resolution: resolved" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 
-	dm = &dbgMessenger{suffix: "debug.local."}
+	dm = newTestDbgMessenger()
 	dm.appendResolution(dns.RcodeServerFailure)
-	if dm.String() != "Domain resolution: failed, " {
+	if dm.String() != "Domain resolution: failed" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 
-	dm = &dbgMessenger{suffix: "debug.local."}
+	dm = newTestDbgMessenger()
 	dm.appendResolution(dns.RcodeNameError)
-	if dm.String() != "Domain resolution: not resolved, " {
+	if dm.String() != "Domain resolution: not resolved" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 }
 
 func TestAppendResponse(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newTestDbgMessenger()
 	r := pdp.Response{
 		Effect: pdp.EffectPermit,
 		Obligations: []pdp.AttributeAssignment{
@@ -152,43 +184,44 @@ func TestAppendResponse(t *testing.T) {
 		},
 	}
 	dm.appendResponse(&r)
-	if dm.String() != "PDP response {Effect: Permit, Obligations: [attr1: value1, attr2: 12345, attr3: 2001:db8::1, ], }, " {
+	if dm.String() != "PDP response {Effect: Permit, Obligations: [attr1: value1, attr2: 12345, attr3: 2001:db8::1]}" {
 		t.Errorf("Unexpected result: %s", dm.String())
 	}
 }
 
 func TestSetDebugQueryPassthroughAnswer(t *testing.T) {
-	dm := &dbgMessenger{suffix: "debug.local."}
+	dm := newDbgMessenger("example.passthrough.local.debug.local.", "")
 	m := testutil.MakeTestDNSMsg("example.passthrough.local", dns.TypeA, dns.ClassINET)
 
-	dm.setDebugQueryPassthroughAnswer("example.passthrough.local.", m)
+	dm.setDebugQueryPassthroughAnswer(m)
 	testutil.AssertDNSMessage(t, "setDebugQueryPassthroughAnswer", 0, m, 0,
 		";; opcode: QUERY, status: NOERROR, id: 0\n"+
 			";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 			";; QUESTION SECTION:\n"+
 			";example.passthrough.local.\tIN\t A\n\n"+
 			";; ANSWER SECTION:\n"+
-			"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Passthrough: yes, \"\n",
+			"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Passthrough: yes\"\n",
 	)
 }
 
 func TestSetDebugQueryAnswer(t *testing.T) {
 	t.Run("OnDomainResponse(RcodeSuccess)", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Out = []pdp.AttributeAssignment{
 			pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.54"),
 			pdp.MakeIntegerAssignment("policy_action", 4),
@@ -197,35 +230,36 @@ func TestSetDebugQueryAnswer(t *testing.T) {
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		dm.setDebugQueryAnswer(m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [redirect_to: 192.0.2.54, policy_action: redirect, ], }, "+
-				"Domain resolution: resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [redirect_to: 192.0.2.54, policy_action: redirect]}\" "+
+				"\"Domain resolution: resolved\"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(RcodeNameError)", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Out = []pdp.AttributeAssignment{
 			pdp.MakeIntegerAssignment("policy_action", 2),
 		}
@@ -233,35 +267,36 @@ func TestSetDebugQueryAnswer(t *testing.T) {
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeNameError)
+		dm.setDebugQueryAnswer(m, dns.RcodeNameError)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"Domain resolution: not resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"Domain resolution: not resolved\"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(RcodeServerFailure)", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Out = []pdp.AttributeAssignment{
 			pdp.MakeIntegerAssignment("policy_action", 2),
 		}
@@ -269,35 +304,36 @@ func TestSetDebugQueryAnswer(t *testing.T) {
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeServerFailure)
+		dm.setDebugQueryAnswer(m, dns.RcodeServerFailure)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"Domain resolution: failed, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"Domain resolution: failed\"\n",
 		)
 	})
 
 	t.Run("OnDomainResponse(-1)", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Out = []pdp.AttributeAssignment{
 			pdp.MakeIntegerAssignment("policy_action", 2),
 		}
@@ -305,36 +341,37 @@ func TestSetDebugQueryAnswer(t *testing.T) {
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, -1)
+		dm.setDebugQueryAnswer(m, -1)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"Domain resolution: skipped, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"Domain resolution: skipped\"\n",
 		)
 	})
 
 	t.Run("OnIPResponse", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 		cfg.attrs.parseAttrList(attrListTypeVal2, "address")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Out = []pdp.AttributeAssignment{
 			pdp.MakeIntegerAssignment("policy_action", 2),
 		}
@@ -350,88 +387,96 @@ func TestSetDebugQueryAnswer(t *testing.T) {
 
 		p.validate(nil, ah, attrListTypeVal2, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		dm.setDebugQueryAnswer(m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: redirect, redirect_to: 192.0.2.54, ], }, "+
-				"Domain resolution: resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: redirect, redirect_to: 192.0.2.54]}\" "+
+				"\"Domain resolution: resolved\"\n",
 		)
 	})
 
 	t.Run("DefaultDecisionOnError", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 		cfg.attrs.parseAttrList(attrListTypeDefDecision, "policy_action=2")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Err = fmt.Errorf("test PDP error")
 		mpc.Effect = pdp.EffectPermit
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		dm.setDebugQueryAnswer(m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"Default decision: [policy_action: allow, ], "+
-				"Domain resolution: resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"Default decision: [policy_action: allow]\" "+
+				"\"Domain resolution: resolved\"\n",
 		)
 	})
 
 	t.Run("DefaultDecisionOnEffectIndeterminate", func(t *testing.T) {
 		p := newPolicyPlugin()
+		p.conf.debugSuffix = "debug.local."
+		p.conf.debugID = "<DEBUG>"
 
 		mpc := testutil.NewMockPdpClient(t)
 		p.pdp = mpc
 
-		dm := newDbgMessenger("debug.local.", "<DEBUG>")
-
-		m := testutil.MakeTestDNSMsg("example.com", dns.TypeA, dns.ClassINET)
+		m := testutil.MakeTestDNSMsg("example.com.debug.local.", dns.TypeTXT, dns.ClassCHAOS)
 		w := testutil.NewTestAddressedNonwriter("192.0.2.1")
+		dm := p.patchDebugMsg(m)
 
 		cfg := newConfig()
 		cfg.attrs.parseAttrList(attrListTypeVal1, "domain_name")
 		cfg.attrs.parseAttrList(attrListTypeDefDecision, "policy_action=2")
 
 		ah := newAttrHolder(nil, cfg.attrs)
-		dn := ah.addDnsQuery(w, m, cfg.options)
+		ah.addDnsQuery(w, m, cfg.options)
 		mpc.Status = fmt.Errorf("test PDP error")
 		mpc.Effect = pdp.EffectIndeterminate
 
 		p.validate(nil, ah, attrListTypeVal1, dm)
 
-		dm.setDebugQueryAnswer(dn, m, dns.RcodeSuccess)
+		dm.setDebugQueryAnswer(m, dns.RcodeSuccess)
 		testutil.AssertDNSMessage(t, "setDebugQueryAnswer", 0, m, 0,
 			";; opcode: QUERY, status: NOERROR, id: 0\n"+
 				";; flags:; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n"+
 				";; QUESTION SECTION:\n"+
 				";example.com.\tIN\t A\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Indeterminate, Obligations: [], }, "+
-				"Default decision: [policy_action: allow, ], "+
-				"Domain resolution: resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Indeterminate, Obligations: []}\" "+
+				"\"Default decision: [policy_action: allow]\" "+
+				"\"Domain resolution: resolved\"\n",
 		)
 	})
+}
+
+const testOrgName = "test.com.debug."
+
+func newTestDbgMessenger() *dbgMessenger {
+	return &dbgMessenger{orgName: testOrgName}
 }

--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -75,14 +75,8 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 			r.Response = true
 			clearECS(r)
 
-			if dbgMsgr != nil && len(r.Question) > 0 {
-				q := r.Question[0]
-
-				q.Name += p.conf.debugSuffix
-				q.Qtype = dns.TypeTXT
-				q.Qclass = dns.ClassCHAOS
-
-				r.Question[0] = q
+			if dbgMsgr != nil {
+				dbgMsgr.restoreDebugMsg(r)
 			}
 
 			if ah.actionValue() != actionDrop && (status != dns.RcodeServerFailure || resolveFailed) {
@@ -107,7 +101,7 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 				status = r.Rcode
 
 				if dbgMsgr != nil {
-					dbgMsgr.setDebugQueryPassthroughAnswer(dn, r)
+					dbgMsgr.setDebugQueryPassthroughAnswer(r)
 					status = dns.RcodeSuccess
 				}
 			}
@@ -132,7 +126,7 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 			status = dns.RcodeServerFailure
 
 			if dbgMsgr != nil {
-				dbgMsgr.setDebugQueryAnswer(dn, r, status)
+				dbgMsgr.setDebugQueryAnswer(r, status)
 				status = dns.RcodeSuccess
 				return dns.RcodeSuccess, nil
 			}
@@ -167,7 +161,7 @@ func (p *policyPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 	}
 
 	if dbgMsgr != nil && ah.actionValue() != actionRefuse {
-		dbgMsgr.setDebugQueryAnswer(dn, r, status)
+		dbgMsgr.setDebugQueryAnswer(r, status)
 		status = dns.RcodeSuccess
 		return dns.RcodeSuccess, nil
 	}

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -150,10 +150,10 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 				";; QUESTION SECTION:\n"+
 				";example.com.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"Domain resolution: resolved, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"Domain resolution: resolved\"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
@@ -399,9 +399,9 @@ func TestPolicyPluginServeDNS(t *testing.T) {
 				";; QUESTION SECTION:\n"+
 				";example.com.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, "+
-				"PDP response {Effect: Permit, Obligations: [policy_action: allow, ], }, "+
-				"Domain resolution: failed, \"\n",
+				"example.com.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" "+
+				"\"PDP response {Effect: Permit, Obligations: [policy_action: allow]}\" "+
+				"\"Domain resolution: failed\"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}
@@ -562,7 +562,7 @@ func TestPolicyPluginServeDNSPassthrough(t *testing.T) {
 				";; QUESTION SECTION:\n"+
 				";example.passthrough.local.debug.local.\tCH\t TXT\n\n"+
 				";; ANSWER SECTION:\n"+
-				"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>, Passthrough: yes, \"\n",
+				"example.passthrough.local.debug.local.\t0\tCH\tTXT\t\"Ident: <DEBUG>\" \"Passthrough: yes\"\n",
 		) {
 			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
 		}


### PR DESCRIPTION
 - the length limit for TXT RR is 255 bytes, so dbgMessenger will
   split single debug messsage into several shorter ones and
   will guarantee that all messages are 255 chars or shorter

 - beautified debug messages

 - added restoreDebugMsg() method to restore original query data