### PR TITLE
policy plugin: updated README

### DIFF
--- a/contrib/coredns/policy/README.md
+++ b/contrib/coredns/policy/README.md
@@ -71,6 +71,24 @@ Option **debug_id** defines a string to be sent with debug response to identify 
 
 Option **log** enables logging PDP request and response attributes
 
+## Predefined attributes
+
+Policy plugin recognizes the following predefined attributes:
+
+ - *domain_name* (type string) - initialized with domain name taken from DNS query.
+
+ - *dns_qtype* (type integer) - initialized with numeric code of query type taken from DNS query. For example, code 1 corresponds to type A, code 28 corresponds to type AAAA, code 5 corresponds to CNAME.
+
+ - *source_ip* (type address) - initialized with IP address from which the DNS query was received.
+
+ - *address* (type address) - assigned with resolved IP address corresponding to query domain name (the first A or AAAA record in DNS response).
+
+ - *policy_action* (type integer) - can be assigned with a value defined in default_decision option or with a value taken from PDP response. The valid values are 1 - Drop, 2 - Allow, 3 - Block, 4 - Redirect, 5 - Refuse.
+
+ - *redirect_to* (type string) - can be assigned with a value defined in default_decision option or with a value taken from PDP response. The valid formats are string representation of IPv4 or IPv6 or domain name.
+
+ - *log* (type integer) - can be assigned with a value defined in default_decision option or with a value taken from PDP response. The attribute defines the dnstap log level, i.e. the attribute set to be sent with DNStap message. See option **dnstap** above. The valid range is from 0 to 2 (inclusive).
+
 ## Example
 
 ~~~ txt

--- a/contrib/coredns/policy/attrholder.go
+++ b/contrib/coredns/policy/attrholder.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/infobloxopen/go-trees/domain"
 	pb "github.com/infobloxopen/themis/contrib/coredns/policy/dnstap"
@@ -48,7 +47,7 @@ func (ah *attrHolder) addDnsQuery(w dns.ResponseWriter, r *dns.Msg, optMap map[u
 		panic(fmt.Errorf("Can't treat %q as domain name: %s", qName, err))
 	}
 	ah.attrs[attrIndexDomainName] = pdp.MakeDomainAssignment(attrNameDomainName, dn)
-	ah.attrs[attrIndexDNSQtype] = pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(qType), 16))
+	ah.attrs[attrIndexDNSQtype] = pdp.MakeIntegerAssignment(attrNameDNSQtype, int64(qType))
 
 	if srcIP := getRemoteIP(w); srcIP != nil {
 		ah.attrs[attrIndexSourceIP] = pdp.MakeAddressAssignment(attrNameSourceIP, srcIP)

--- a/contrib/coredns/policy/attrholder_test.go
+++ b/contrib/coredns/policy/attrholder_test.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"net"
-	"strconv"
 	"testing"
 
 	"github.com/infobloxopen/go-trees/domain"
@@ -67,7 +66,7 @@ func TestAddDnsQuery(t *testing.T) {
 	ah.addDnsQuery(w, m, cfg.options)
 	testutil.AssertAttrList(t, ah.attrs,
 		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain(dns.Fqdn("example.com"))),
-		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeIntegerAssignment(attrNameDNSQtype, int64(dns.TypeA)),
 		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("2001:db8::1")),
 		emptyAttr, emptyAttr, emptyAttr, emptyAttr,
 		pdp.MakeStringAssignment("low", "0001020304050607"),
@@ -92,7 +91,7 @@ func TestAddDnsQuery(t *testing.T) {
 	ah.addDnsQuery(w, m, cfg.options)
 	testutil.AssertAttrList(t, ah.attrs,
 		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain(dns.Fqdn("example.com"))),
-		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeIntegerAssignment(attrNameDNSQtype, int64(dns.TypeA)),
 		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
 		emptyAttr, emptyAttr, emptyAttr, emptyAttr,
 		pdp.MakeStringAssignment("low", "0001020304050607"),

--- a/contrib/coredns/policy/dns.go
+++ b/contrib/coredns/policy/dns.go
@@ -50,9 +50,11 @@ func getRespIP(r *dns.Msg) net.IP {
 		switch rr := rr.(type) {
 		case *dns.A:
 			ip = rr.A
+			break
 
 		case *dns.AAAA:
 			ip = rr.AAAA
+			break
 		}
 	}
 

--- a/contrib/coredns/policy/policy_test.go
+++ b/contrib/coredns/policy/policy_test.go
@@ -64,7 +64,7 @@ func TestPolicyPluginValidate(t *testing.T) {
 	}
 	testutil.AssertAttrList(t, ah.attrs,
 		pdp.MakeDomainAssignment(attrNameDomainName, testutil.MakeTestDomain(dns.Fqdn("example.com"))),
-		pdp.MakeStringAssignment(attrNameDNSQtype, "1"),
+		pdp.MakeIntegerAssignment(attrNameDNSQtype, int64(dns.TypeA)),
 		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
 		emptyAttr,
 		pdp.MakeIntegerAssignment("policy_action", 4),


### PR DESCRIPTION
 - added info about predefined attributes

 - choose the first A or AAAA record from DNS response for
   validation since it is more likely that user will use
   the first IP rather than the last one

 - make "dns_qtype" attribute integer