### PR TITLE
policy plugin: make VALUE_COUNT lowercase

### DIFF
--- a/contrib/coredns/policy/metrics.go
+++ b/contrib/coredns/policy/metrics.go
@@ -246,7 +246,7 @@ func (g *AttrGauge) tick() uint32 {
 			g.pgv.DeleteLabelValues(attr, val)
 			delete(amap, val)
 		}
-		g.pgv.WithLabelValues(attr, "VALUES_COUNT").Set(float64(len(amap)))
+		g.pgv.WithLabelValues(attr, "values_count").Set(float64(len(amap)))
 	}
 	return atomic.SwapUint32(&g.errCnt, 0)
 }


### PR DESCRIPTION
 - cosmetic issue in metrics. Make VALUE_COUNT lowercase to have it
   at the end of list of alphabetically sorted hexadecimal labels in
   prometheus output