### PR TITLE
Add API description to ctrl_storage endpoint & Make AttributeAssignment Marshalable

### DIFF
--- a/pdp/assignment.go
+++ b/pdp/assignment.go
@@ -1,6 +1,7 @@
 package pdp
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 
@@ -16,6 +17,14 @@ import (
 type AttributeAssignment struct {
 	a Attribute
 	e Expression
+}
+
+// AttribAssignFmt is the json marshal format of serialized AttributeAssignment
+type AttribAssignFmt struct {
+	Name      string
+	NameType  string
+	Value     string
+	ValueType string
 }
 
 // MakeAttributeAssignment creates assignment of given expression to given
@@ -458,6 +467,20 @@ func (a AttributeAssignment) String() string {
 		return err.Error()
 	}
 	return fmt.Sprintf("(%s)%s:%s", valueType, name, value)
+}
+
+// MarshalJSON satisfies Marshaler interface
+func (a AttributeAssignment) MarshalJSON() ([]byte, error) {
+	name, valueType, value, err := a.Serialize(nil)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(AttribAssignFmt{
+		Name:      name,
+		NameType:  a.a.t.GetKey(),
+		Value:     value,
+		ValueType: valueType,
+	})
 }
 
 func (a AttributeAssignment) bindError(err error) error {

--- a/pdp/assignment.go
+++ b/pdp/assignment.go
@@ -471,6 +471,8 @@ func (a AttributeAssignment) String() string {
 }
 
 // MarshalJSON satisfies Marshaler interface
+// Only works for assignment expression where righthand doesn't depend on context
+// E.g.: values, constant expression, selector that don't rely on attributes or local content
 func (a AttributeAssignment) MarshalJSON() ([]byte, error) {
 	name, valueType, value, err := a.Serialize(emptyCtx)
 	if err != nil {

--- a/pdp/assignment.go
+++ b/pdp/assignment.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
+var emptyCtx, _ = NewContext(nil, 0, nil)
+
 // AttributeAssignment represents assignment of arbitrary result to
 // an attribute.
 type AttributeAssignment struct {
@@ -21,10 +23,9 @@ type AttributeAssignment struct {
 
 // AttribAssignFmt is the json marshal format of serialized AttributeAssignment
 type AttribAssignFmt struct {
-	Name      string
-	NameType  string
-	Value     string
-	ValueType string
+	Name  string
+	Type  string
+	Value string
 }
 
 // MakeAttributeAssignment creates assignment of given expression to given
@@ -462,7 +463,7 @@ func (a AttributeAssignment) Serialize(ctx *Context) (string, string, string, er
 }
 
 func (a AttributeAssignment) String() string {
-	name, valueType, value, err := a.Serialize(nil)
+	name, valueType, value, err := a.Serialize(emptyCtx)
 	if err != nil {
 		return err.Error()
 	}
@@ -471,15 +472,14 @@ func (a AttributeAssignment) String() string {
 
 // MarshalJSON satisfies Marshaler interface
 func (a AttributeAssignment) MarshalJSON() ([]byte, error) {
-	name, valueType, value, err := a.Serialize(nil)
+	name, valueType, value, err := a.Serialize(emptyCtx)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(AttribAssignFmt{
-		Name:      name,
-		NameType:  a.a.t.GetKey(),
-		Value:     value,
-		ValueType: valueType,
+		Name:  name,
+		Type:  valueType,
+		Value: value,
 	})
 }
 

--- a/pdp/assignment_test.go
+++ b/pdp/assignment_test.go
@@ -1,8 +1,10 @@
 package pdp
 
 import (
+	"encoding/json"
 	"math"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +26,15 @@ func TestAttributeAssignment(t *testing.T) {
 		t.Errorf("Expected no error but got %s", err)
 	} else if id != a.id || tKey != a.t.GetKey() || s != expect {
 		t.Errorf("Expected %q, %q, %q but got %q, %q, %q", a.id, a.t.GetKey(), expect, id, tKey, s)
+	}
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"string","Value":"test-value"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
 	}
 
 	dv := MakeDomainValue(makeTestDomain("example.com"))
@@ -112,6 +123,15 @@ func TestAttributeAssignment(t *testing.T) {
 		t.Errorf("Expected %q, %q, %q but got %q, %q, %q", a.id, a.t.GetKey(), expect, id, tKey, s)
 	}
 
+	bjson, err = json.Marshal(aa)
+	expectb = `{"Name":"test-id","Type":"float","Value":"45679.23"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	v = MakeIntegerValue(12345)
 	a = Attribute{
 		id: "test-id",
@@ -151,6 +171,15 @@ func TestMakeExpressionAssignment(t *testing.T) {
 		),
 	)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"boolean","Value":"false"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	v, err := aa.calculate(ctx)
 	if err != nil {
 		t.Error(err)
@@ -187,6 +216,15 @@ func TestBooleanAssignment(t *testing.T) {
 
 	aa := MakeBooleanAssignment("test-id", true)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"boolean","Value":"true"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	b, err := aa.GetBoolean(ctx)
 	if err != nil {
 		t.Error(err)
@@ -221,6 +259,15 @@ func TestStringAssignment(t *testing.T) {
 	}
 
 	aa := MakeStringAssignment("test-id", "test")
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"string","Value":"test"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	s, err := aa.GetString(ctx)
 	if err != nil {
@@ -257,6 +304,15 @@ func TestIntegerAssignment(t *testing.T) {
 
 	aa := MakeIntegerAssignment("test-id", math.MaxInt64)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"integer","Value":"9223372036854775807"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	i, err := aa.GetInteger(ctx)
 	if err != nil {
 		t.Error(err)
@@ -291,6 +347,15 @@ func TestFloatAssignment(t *testing.T) {
 	}
 
 	aa := MakeFloatAssignment("test-id", math.SmallestNonzeroFloat64)
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"float","Value":"5E-324"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	f, err := aa.GetFloat(ctx)
 	if err != nil {
@@ -327,6 +392,15 @@ func TestAddressAssignment(t *testing.T) {
 
 	aa := MakeAddressAssignment("test-id", net.ParseIP("192.0.2.1"))
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"address","Value":"192.0.2.1"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	a, err := aa.GetAddress(ctx)
 	if err != nil {
 		t.Error(err)
@@ -361,6 +435,15 @@ func TestNetworkAssignment(t *testing.T) {
 	}
 
 	aa := MakeNetworkAssignment("test-id", makeTestNetwork("192.0.2.0/24"))
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"network","Value":"192.0.2.0/24"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	n, err := aa.GetNetwork(ctx)
 	if err != nil {
@@ -397,6 +480,15 @@ func TestDomainAssignment(t *testing.T) {
 
 	aa := MakeDomainAssignment("test-id", makeTestDomain("example.com"))
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"domain","Value":"example.com"}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	d, err := aa.GetDomain(ctx)
 	if err != nil {
 		t.Error(err)
@@ -431,6 +523,15 @@ func TestSetOfStringsAssignment(t *testing.T) {
 	}
 
 	aa := MakeSetOfStringsAssignment("test-id", newStrTree("one", "two", "three"))
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"set of strings","Value":"\"one\",\"two\",\"three\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	ss, err := aa.GetSetOfStrings(ctx)
 	if err != nil {
@@ -474,6 +575,15 @@ func TestSetOfNetworksAssignment(t *testing.T) {
 		),
 	)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"set of networks","Value":"\"192.0.2.16/28\",\"192.0.2.32/28\",\"192.0.2.48/28\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	sn, err := aa.GetSetOfNetworks(ctx)
 	if err != nil {
 		t.Error(err)
@@ -516,6 +626,15 @@ func TestSetOfDomainsAssignment(t *testing.T) {
 		),
 	)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"set of domains","Value":"\"example.com\",\"example.net\",\"example.org\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	sd, err := aa.GetSetOfDomains(ctx)
 	if err != nil {
 		t.Error(err)
@@ -551,6 +670,15 @@ func TestListOfStringsAssignment(t *testing.T) {
 	}
 
 	aa := MakeListOfStringsAssignment("test-id", []string{"one", "two", "three"})
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"list of strings","Value":"\"one\",\"two\",\"three\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	ls, err := aa.GetListOfStrings(ctx)
 	if err != nil {
@@ -600,6 +728,15 @@ func TestFlags8Assignment(t *testing.T) {
 
 	aa := MakeFlags8Assignment("test-id", nt, 21)
 
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"f8flags","Value":"\"f00\",\"f02\",\"f04\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
+
 	f8, err := aa.GetFlags8(ctx)
 	if err != nil {
 		t.Error(err)
@@ -648,6 +785,15 @@ func TestFlags16Assignment(t *testing.T) {
 	}
 
 	aa := MakeFlags16Assignment("test-id", nt, 21)
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"f16flags","Value":"\"f00\",\"f02\",\"f04\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	f16, err := aa.GetFlags16(ctx)
 	if err != nil {
@@ -699,6 +845,15 @@ func TestFlags32Assignment(t *testing.T) {
 	}
 
 	aa := MakeFlags32Assignment("test-id", nt, 21)
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"f32flags","Value":"\"f00\",\"f02\",\"f04\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	f32, err := aa.GetFlags32(ctx)
 	if err != nil {
@@ -754,6 +909,15 @@ func TestFlags64Assignment(t *testing.T) {
 	}
 
 	aa := MakeFlags64Assignment("test-id", nt, 21)
+
+	bjson, err := json.Marshal(aa)
+	expectb := `{"Name":"test-id","Type":"f64flags","Value":"\"f00\",\"f02\",\"f04\""}`
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	} else if strings.Compare(expectb, string(bjson)) != 0 {
+		t.Errorf("Expected marshaled as '%s' but got '%s'",
+			expectb, string(bjson))
+	}
 
 	f64, err := aa.GetFlags64(ctx)
 	if err != nil {

--- a/pdpserver/server/ctrl_storage.go
+++ b/pdpserver/server/ctrl_storage.go
@@ -19,15 +19,15 @@ by the depth parameter.
 
 Parameters:
 
-    path    an optional url parameter in the form of 'id1/id2/id3' where id2 is
-            the child of id1, and id3 is child of id2. The node with the right
-            most id is selected as displayed root (id3 in this case).
+	path    Is an optional url parameter in the form of 'id1/id2/.../id3'
+			where id2 is the child of id1.
+			Select the subtree of the right-most id in this path
+			(id3 in above case).
             By default, the path is empty (the root node is selected).
 
-    depth   an optional query parameter that is a positive integer.
-            This parameter specifies the maximum depth of the subtree displayed
-            in addition to the selected node. For example, a depth of 1
-            displays the selected node and its children.
+    depth   Is an optional query string parameter taking a positive integer.
+			Display a subtree with at most depth specified.
+			E.g.: depth=1 displays the selected root and its children.
             By default, the depth is 0 (only display the selected node).
 
 GET /query/<path>?depth=<depth>`

--- a/pdpserver/server/ctrl_storage.go
+++ b/pdpserver/server/ctrl_storage.go
@@ -11,6 +11,26 @@ import (
 const (
 	queryCmd          = "query"
 	missingStorageMsg = `"Server missing policy storage"`
+	usage             = `PDP storage traversal API:
+Description: This API displays the ord, id, target, obligation, and algorithm
+information of specific nodes/subtree in the pdp storage tree. The subtree root
+is identified by the path parameter, and the depth of the subtree is specified
+by the depth parameter.
+
+Parameters:
+
+    path    an optional url parameter in the form of 'id1/id2/id3' where id2 is
+            the child of id1, and id3 is child of id2. The node with the right
+            most id is selected as displayed root (id3 in this case).
+            By default, the path is empty (the root node is selected).
+
+    depth   an optional query parameter that is a positive integer.
+            This parameter specifies the maximum depth of the subtree displayed
+            in addition to the selected node. For example, a depth of 1
+            displays the selected node and its children.
+            By default, the depth is 0 (only display the selected node).
+
+GET /query/<path>?depth=<depth>`
 )
 
 type storageHandler struct {
@@ -24,7 +44,8 @@ func (handler *storageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	)
 	path := strings.FieldsFunc(r.URL.Path, func(c rune) bool { return c == '/' })
 	if len(path) == 0 || path[0] != queryCmd {
-		http.Error(w, "404 page not found", 404)
+		http.Error(w, usage, 404)
+		return
 	}
 
 	// parse depth

--- a/pdpserver/server/ctrl_storage.go
+++ b/pdpserver/server/ctrl_storage.go
@@ -101,7 +101,9 @@ func (handler *storageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	switch cmd {
 	case queryCmd:
+		handler.s.RLock()
 		handleQuery(w, handler.s.p, resourcePath, urlQuery)
+		handler.s.RUnlock()
 	default:
 		http.Error(w, fmt.Sprintf("Unknown resource %s\n%s", cmd, usage), http.StatusNotFound)
 	}

--- a/pdpserver/server/ctrl_storage_test.go
+++ b/pdpserver/server/ctrl_storage_test.go
@@ -50,8 +50,7 @@ func TestHandleQuery(t *testing.T) {
 	root := pdp.NewPolicySet("test", false, pdp.Target{}, []pdp.Evaluable{policy},
 		pdp.PolicyCombiningAlgs["firstapplicableeffect"], nil, nil)
 
-	p := pdp.NewPolicyStorage(root, pdp.Symbols{}, nil)
-	s := &Server{p: p}
+	s := pdp.NewPolicyStorage(root, pdp.Symbols{}, nil)
 
 	handleQuery(&w, s, []string{}, url.Values{"depth": []string{"nine"}})
 	assertEqualWriter(t, mockResponseWriter{

--- a/pdpserver/server/ctrl_storage_test.go
+++ b/pdpserver/server/ctrl_storage_test.go
@@ -50,7 +50,8 @@ func TestHandleQuery(t *testing.T) {
 	root := pdp.NewPolicySet("test", false, pdp.Target{}, []pdp.Evaluable{policy},
 		pdp.PolicyCombiningAlgs["firstapplicableeffect"], nil, nil)
 
-	s := pdp.NewPolicyStorage(root, pdp.Symbols{}, nil)
+	p := pdp.NewPolicyStorage(root, pdp.Symbols{}, nil)
+	s := &Server{p: p}
 
 	handleQuery(&w, s, []string{}, url.Values{"depth": []string{"nine"}})
 	assertEqualWriter(t, mockResponseWriter{

--- a/pdpserver/server/ctrl_storage_test.go
+++ b/pdpserver/server/ctrl_storage_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/infobloxopen/themis/pdp"
+)
+
+type mockResponseWriter struct {
+	statusCode int
+	msg        string
+}
+
+func (w *mockResponseWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (w *mockResponseWriter) Write(b []byte) (int, error) {
+	w.msg += string(b)
+	return len(b), nil
+}
+
+func (w *mockResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *mockResponseWriter) clear() {
+	w.statusCode = 0
+	w.msg = ""
+}
+
+func TestHandleQuery(t *testing.T) {
+	var w mockResponseWriter
+
+	handleQuery(&w, nil, []string{}, url.Values{})
+	assertEqualWriter(t, mockResponseWriter{
+		statusCode: http.StatusNotFound,
+		msg:        missingStorageMsg,
+	}, w, "On nil storage:")
+	w.clear()
+
+	rule := pdp.NewRule("permit", false, pdp.Target{}, nil, pdp.EffectPermit, nil)
+
+	policy := pdp.NewPolicy("first", false, pdp.Target{}, []*pdp.Rule{rule},
+		pdp.RuleCombiningAlgs["firstapplicableeffect"], nil, nil)
+
+	root := pdp.NewPolicySet("test", false, pdp.Target{}, []pdp.Evaluable{policy},
+		pdp.PolicyCombiningAlgs["firstapplicableeffect"], nil, nil)
+
+	s := pdp.NewPolicyStorage(root, pdp.Symbols{}, nil)
+
+	handleQuery(&w, s, []string{}, url.Values{"depth": []string{"nine"}})
+	assertEqualWriter(t, mockResponseWriter{
+		statusCode: http.StatusBadRequest,
+		msg:        "\"strconv.ParseUint: parsing \\\"nine\\\": invalid syntax\"",
+	}, w, "On bad depth:")
+	w.clear()
+
+	handleQuery(&w, s, []string{"test", "second"}, url.Values{"depth": []string{"3"}})
+	assertEqualWriter(t, mockResponseWriter{
+		statusCode: http.StatusNotFound,
+		msg:        "\"#72: Path [test second] not found\"",
+	}, w, "On not found path:")
+	w.clear()
+
+	handleQuery(&w, s, []string{"test", "first"}, url.Values{"depth": []string{"3"}})
+	assertEqualWriter(t, mockResponseWriter{
+		statusCode: http.StatusOK,
+		msg:        "{\"ord\":0,\"id\":\"first\",\"target\":{},\"obligations\":null,\"algorithm\":{\"type\":\"firstApplicableEffectRCA\"},\"rules\":[{\"ord\":0,\"id\":\"permit\",\"target\":{},\"obligations\":null,\"effect\":\"Permit\"}]}",
+	}, w, "On found:")
+	w.clear()
+}
+
+func assertEqualWriter(t *testing.T, expect, got mockResponseWriter, failPrefix string) {
+	if expect.statusCode != got.statusCode {
+		t.Errorf(failPrefix+"expected status %d, got %d", expect.statusCode, got.statusCode)
+	}
+	expectMsg, gotMsg := strings.TrimSpace(expect.msg), strings.TrimSpace(got.msg)
+	if strings.Compare(expectMsg, gotMsg) != 0 {
+		t.Errorf(failPrefix+"expected message \"%s\", got \"%s\"", expectMsg, gotMsg)
+	}
+}


### PR DESCRIPTION
I've noticed that the storage control/query endpoint has very few API documentation, so I'm adding the usage description to 404 error message. I've also exposed AttributeAssignment values when marshaling to JSON to get information on obligations.