### PR TITLE
Pepcli update: list of strings and cl-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ Other pdpserver options:
 - `-v` - log verbosity (0 - error, 1 - warn (default), 2 - info, 3 - debug).
 
 ## Requests
-To make decision requests there are 3 options. Create client from scratch which implements protocol defined by `proto/service.proto`, use golang client package `themis\pep` to implement client application (see `contrib/coredns/policy`) and for debug use simple PEPCLI client. To use PEPCLI client create requests YAML file for example:
+To make decision requests, there are 3 options: create client from scratch which implements protocol defined by `proto/service.proto`, use golang client package `themis\pep` to implement client application (see `contrib/coredns/policy`), and for debug use simple PEPCLI client. To use PEPCLI, requests can be read in with `-i` (strings ending in `.yaml` or `.json` will be treated as a filepath; anything else is parsed as raw JSON), for example:
 ```yaml
 attributes:
   s: string

--- a/examples/12-lists/README.md
+++ b/examples/12-lists/README.md
@@ -1,0 +1,69 @@
+# 12-Lists
+
+The example shows policies file with lists of strings functions.
+
+Run pdpserver using policy file:
+```
+$ pdpserver -v 3 -pfmt yaml -p lists.yaml
+INFO[0000] Starting PDP server
+INFO[0000] Loading policy                                policy=lists.yaml
+INFO[0000] Parsing policy                                policy=lists.yaml
+INFO[0000] Opening control port                          address=":5554"
+INFO[0000] Opening storage port                          address=":5552"
+INFO[0000] Creating service protocol handler
+INFO[0000] Creating control protocol handler
+INFO[0000] Serving control requests
+INFO[0000] Opening service port                          address=":5555"
+INFO[0000] Serving decision requests
+```
+
+In other terminal run pepcli:
+```
+$ pepcli -i lists.requests.yaml test
+- effect: Deny
+  obligation:
+    - id: "i"
+      type: "list of strings"
+      value: ""
+
+- effect: Deny
+  obligation:
+    - id: "i"
+      type: "list of strings"
+      value: ""
+
+- effect: Permit
+  obligation:
+    - id: "i"
+      type: "list of strings"
+      value: "\"foo\""
+
+- effect: Permit
+  obligation:
+    - id: "i"
+      type: "list of strings"
+      value: "\"foo\",\"bar\""
+      
+```
+
+PDP logs:
+```
+...
+DEBU[0008] Request context                               context="attributes:
+- ls.(List of Strings): []"
+DEBU[0008] Response                                      effect=Deny obligations="attributes:
+- i.(list of strings): \"\"" reason="<nil>"
+DEBU[0008] Request context                               context="attributes:
+- ls.(List of Strings): [\"\", \"baz\"]"
+DEBU[0008] Response                                      effect=Deny obligations="attributes:
+- i.(list of strings): \"\"" reason="<nil>"
+DEBU[0008] Request context                               context="attributes:
+- ls.(List of Strings): [\"\", \"\", ...]"
+DEBU[0008] Response                                      effect=Permit obligations="attributes:
+- i.(list of strings): \"\\\"foo\\\"\"" reason="<nil>"
+DEBU[0008] Request context                               context="attributes:
+- ls.(List of Strings): [\"\", \"\", ...]"
+DEBU[0008] Response                                      effect=Permit obligations="attributes:
+- i.(list of strings): \"\\\"foo\\\",\\\"bar\\\"\"" reason="<nil>"
+...
+```

--- a/examples/12-lists/lists.requests.yaml
+++ b/examples/12-lists/lists.requests.yaml
@@ -1,0 +1,17 @@
+attributes:
+  ls: list of strings
+
+requests:
+- ls: []
+
+- ls:
+  - baz
+
+- ls:
+  - foo
+  - baz
+
+- ls:
+  - foo
+  - bar
+  - baz

--- a/examples/12-lists/lists.yaml
+++ b/examples/12-lists/lists.yaml
@@ -1,0 +1,32 @@
+attributes:
+  ls: list of strings
+  i: list of strings
+
+policies:
+  alg: FirstApplicableEffect
+  obligations:
+  - i:
+      intersect:
+      - val:
+          type: list of strings
+          content:
+          - foo
+          - bar
+      - attr: ls
+  rules:
+  - effect: Permit
+    condition:
+      not:
+      - equal:
+        - len:
+          - intersect:
+            - val:
+                type: list of strings
+                content:
+                - foo
+                - bar
+            - attr: ls
+        - val:
+            type: integer
+            content: 0
+  - effect: Deny

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,4 +13,5 @@ Here gathered set of examples which can help to understand, investigate and debu
 - **08-mapper** - example of mapper combining algorithm;
 - **09-numerical** - example use of numerical functions;
 - **10-flags** - example use of custom flags type;
-- **11-funcs** - example of functions such as try and concat.
+- **11-funcs** - example of functions such as try and concat;
+- **12-lists** - example use of list of strings functions.

--- a/pepcli/README.md
+++ b/pepcli/README.md
@@ -48,7 +48,7 @@ python grinder.py -o test.html -t Test ./
 The latest command collects all test-&lt;number&gt;.json files and creates report based on all of them.
 
 ## Formats
-PEPCLI expects requests as YAML file. The file should contain two sections **attributes** and **requests**. Attributes section represents map which defines attribute and its type. Requests section lists all requests. Each request is a map of attribute name to its value:
+PEPCLI can take in PDP requests as a filepath pointing to a YAML or JSON file, or raw JSON. This guide will use requests as a YAML file. The file should contain two sections **attributes** and **requests**. Attributes section represents map which defines attribute and its type. Requests section lists all requests. Each request is a map of attribute name to its value:
 ```yaml
 attributes:
   s: string

--- a/pepcli/README.md
+++ b/pepcli/README.md
@@ -1,6 +1,10 @@
 # PEPCLI - Policy Enforcement Point Command Line Interface
 PEPCLI implements simple PEP as well as a tool to measure performance of PDP server.
 
+## Input
+PEPCLI can take in PDP requests in three different ways using `-i`: raw JSON, or as a filepath pointing to a YAML or JSON file.
+Any string ending in `.yaml` or `.json` will be recognized as pointing to a file; anything other input is processed as raw JSON.
+
 ## Decision requests
 The utility can make decision requests with help of `test` command. There is a bunch of [examples](../examples) in the repository. Additionally, PEPCLI can reach server on remote machine if its address is specified like below:
 ```
@@ -48,7 +52,7 @@ python grinder.py -o test.html -t Test ./
 The latest command collects all test-&lt;number&gt;.json files and creates report based on all of them.
 
 ## Formats
-PEPCLI can take in PDP requests as a filepath pointing to a YAML or JSON file, or raw JSON. This guide will use requests as a YAML file. The file should contain two sections **attributes** and **requests**. Attributes section represents map which defines attribute and its type. Requests section lists all requests. Each request is a map of attribute name to its value:
+This guide will use requests input as a YAML file. The file should contain two sections, **attributes** and **requests**. Attributes section represents map which defines attribute and its type. Requests section lists all requests. Each request is a map of attribute name to its value:
 ```yaml
 attributes:
   s: string

--- a/pepcli/config.go
+++ b/pepcli/config.go
@@ -89,7 +89,7 @@ func init() {
 	flag.Var(&conf.servers, "s", "PDP server to work with (default 127.0.0.1:5555, "+
 		"allowed use multiple to distribute load)")
 	flag.BoolVar(&conf.hotSpot, "hot-spot", false, "enables \"hot spot\" balancer (works only for gRPC streaming")
-	flag.StringVar(&conf.input, "i", "requests.yaml", "file with YAML formatted list of requests to send to PDP")
+	flag.StringVar(&conf.input, "i", "requests.yaml", "formatted list of requests to send to PDP, may be one of 1) YAML filepath, 2) JSON filepath, or 3) raw JSON")
 	flag.IntVar(&conf.count, "n", 0, "number or requests to send\n\t"+
 		"(default and value less than one means all requests from file)")
 	flag.IntVar(&conf.streams, "streams", 0, "number of streams to use with gRPC streaming (< 1 unary gRPC)")

--- a/pepcli/requests/requests.go
+++ b/pepcli/requests/requests.go
@@ -314,12 +314,12 @@ func listOfStringsMarshaller(value interface{}) (pdp.AttributeValue, error) {
 	}
 
 	los := make([]string, len(v))
-	for _, s := range v {
+	for i, s := range v {
 		switch value := s.(type) {
 		case string:
 			los = append(los, value)
 		default:
-			return pdp.UndefinedValue, fmt.Errorf("can't marshal %T as string in list of strings", s)
+			return pdp.UndefinedValue, fmt.Errorf("can't marshal %T at %d as string in list of strings", s, i+1)
 		}
 	}
 

--- a/pepcli/requests/requests.go
+++ b/pepcli/requests/requests.go
@@ -278,7 +278,7 @@ func domainMarshaller(value interface{}) (pdp.AttributeValue, error) {
 func listOfStringsMarshaller(value interface{}) (pdp.AttributeValue, error) {
 	v, ok := value.([]interface{})
 	if !ok {
-		return pdp.UndefinedValue, fmt.Errorf("can't marshal %T as list of interface{}", value)
+		return pdp.UndefinedValue, fmt.Errorf("can't marshal %T as list of string", value)
 	}
 	if len(v) == 0 {
 		return pdp.MakeListOfStringsValue([]string{}), nil

--- a/pepcli/requests/requests.go
+++ b/pepcli/requests/requests.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	YAML = "yaml"
-	JSON = "json"
+	YAML          = "yaml"
+	JSON          = "json"
+	MaxFloat64Int = 1 << 53 // 9,007,199,254,740,992--the maximum IEEE-754 double float integer is not a golang const
 )
 
 type requests struct {
@@ -211,7 +212,7 @@ func integerMarshaller(value interface{}) (pdp.AttributeValue, error) {
 		err = fmt.Errorf("can't marshal %T (%d) as int64", value, value)
 
 	case float64:
-		if value > -9007199254740992 && value < 9007199254740992 {
+		if value > -MaxFloat64Int && value < MaxFloat64Int {
 			return pdp.MakeIntegerValue(int64(value)), nil
 		}
 		err = fmt.Errorf("can't marshal %T (%g) as int64", value, value)

--- a/pepcli/test/config.go
+++ b/pepcli/test/config.go
@@ -9,6 +9,7 @@ import (
 )
 
 type config struct {
+	sort bool
 }
 
 var testFlagSet = flag.NewFlagSet(Name, flag.ExitOnError)
@@ -18,6 +19,7 @@ func FlagsParser(args []string) interface{} {
 	conf := config{}
 
 	testFlagSet.Usage = usage
+	testFlagSet.BoolVar(&conf.sort, "sort", false, "sort lists of strings in returned obligations")
 	testFlagSet.Parse(args)
 
 	count := testFlagSet.NArg()


### PR DESCRIPTION
Updates pepcli to handle list of strings and add some command line functionality:
- 	pepcli now can marshal list of string type and guess for list of strings
- 	pepcli takes in JSON or YAML filepaths or raw JSON for “-i” arg (fully backwards compatible)
- 	pepcli test package has flagparser option to sort list of strings returned in pdp response obligations
- 	examples package now has 12-lists, which covers a few brief pepcli use cases

New functionality can be tested with these generic commands (json not provided in PR):
- `pepcli -i '{"attributes”:{…},”requests”:[{…},…]}' test/perf` [raw json]
- `pepcli -i requests.json test/perf` [json filepath]
- `pepcli -i requests.yaml test -sort` [sort option]