### PR TITLE
pepcli string list marshaller fix

### DIFF
--- a/pepcli/requests/requests.go
+++ b/pepcli/requests/requests.go
@@ -317,9 +317,9 @@ func listOfStringsMarshaller(value interface{}) (pdp.AttributeValue, error) {
 	for i, s := range v {
 		switch value := s.(type) {
 		case string:
-			los = append(los, value)
+			los[i] = value
 		default:
-			return pdp.UndefinedValue, fmt.Errorf("can't marshal %T at %d as string in list of strings", s, i+1)
+			return pdp.UndefinedValue, fmt.Errorf("can't marshal %T at %d as string in list of strings", s, i)
 		}
 	}
 


### PR DESCRIPTION
pepcli’s list of strings function always included the first few fields as empty “” (this is because the list was appended after being created); this led to false positives in anything that checked intersection, len, or contents of a list of strings. This update changes the list of strings marshaller to properly reflect the actual values intended without extra empty values.