### PR TITLE
Added new format for redirect string

### DIFF
--- a/contrib/coredns/policy/dns.go
+++ b/contrib/coredns/policy/dns.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/miekg/dns"
 )
 
-var errInvalidDNSMessage = errors.New("invalid DNS message")
+var (
+	errInvalidDNSMessage = errors.New("invalid DNS message")
+	// Several rrCodes could be configured together separated by rrCodeDelimiter, each rrCode and it's record is separarated by rrCodePrefixDelimiter
+	rrCodeDelimiter       = ";"
+	rrCodePrefixDelimiter = "="
+)
 
 func getNameAndType(r *dns.Msg) (string, uint16) {
 	if r == nil || len(r.Question) <= 0 {
@@ -28,6 +34,16 @@ func getNameAndClass(r *dns.Msg) (string, uint16) {
 
 	q := r.Question[0]
 	return q.Name, q.Qclass
+}
+
+// helper function to get name, type and class from the question section of the request
+func getNameTypeAndClass(r *dns.Msg) (string, uint16, uint16) {
+	if r == nil || len(r.Question) <= 0 {
+		return ".", dns.TypeNone, dns.ClassNONE
+	}
+
+	q := r.Question[0]
+	return q.Name, q.Qtype, q.Qclass
 }
 
 func getRemoteIP(w dns.ResponseWriter) net.IP {
@@ -114,45 +130,49 @@ func resetTTL(r *dns.Msg) *dns.Msg {
 }
 
 func (p *policyPlugin) setRedirectQueryAnswer(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, dst string) (int, error) {
-
-	qName, qClass := getNameAndClass(r)
-
-	ip := net.ParseIP(dst)
-	rr := ip2rr(ip, qName, qClass)
-	if rr == nil {
-
-		dst = dns.Fqdn(dst)
-		rr = &dns.CNAME{
-			Hdr: dns.RR_Header{
-				Name:   qName,
-				Rrtype: dns.TypeCNAME,
-				Class:  qClass,
-			},
-			Target: dst,
-		}
-
-		if r == nil || len(r.Question) <= 0 {
-			return dns.RcodeServerFailure, errInvalidDNSMessage
-		}
-
-		origName := qName
-		r.Question[0].Name = dst
-
-		nw := nonwriter.New(w)
-		if _, err := plugin.NextOrFailure(p.Name(), p.next, ctx, nw, r); err != nil {
-			r.Question[0].Name = origName
-			return dns.RcodeServerFailure, err
-		}
-
-		nw.Msg.CopyTo(r)
-		r.Question[0].Name = origName
-
-		r.Answer = append([]dns.RR{rr}, r.Answer...)
-		r.Authoritative = true
-		return r.Rcode, nil
+	if r == nil || len(r.Question) <= 0 {
+		return dns.RcodeServerFailure, errInvalidDNSMessage
 	}
 
-	r.Answer = []dns.RR{rr}
+	var rr dns.RR
+	qName, qType, qClass := getNameTypeAndClass(r)
+	record := findRecord(dst, qType)
+	switch qType {
+	case dns.TypeA, dns.TypeAAAA:
+		ip := net.ParseIP(record)
+		if rr = ip2rr(ip, qName, qClass); rr != nil {
+			break
+		}
+		if cName := findRecord(dst, dns.TypeCNAME); cName != "" {
+			return p.resolveByCname(ctx, w, r, cName, qName, qClass)
+		}
+	case dns.TypeTXT:
+		if len(record) > 0 {
+			rr = &dns.TXT{
+				Hdr: dns.RR_Header{
+					Name:   qName,
+					Rrtype: dns.TypeTXT,
+					Class:  qClass,
+				},
+				Txt: []string{record},
+			}
+		}
+	case dns.TypeCNAME:
+		if len(record) > 0 {
+			rr = &dns.CNAME{
+				Hdr: dns.RR_Header{
+					Name:   qName,
+					Rrtype: dns.TypeCNAME,
+					Class:  qClass,
+				},
+				Target: record,
+			}
+		}
+	}
+
+	if rr != nil {
+		r.Answer = []dns.RR{rr}
+	}
 	r.Rcode = dns.RcodeSuccess
 	return r.Rcode, nil
 }
@@ -179,4 +199,53 @@ func ip2rr(ip net.IP, name string, class uint16) dns.RR {
 		}
 	}
 	return nil
+}
+
+// find record will return record for typ if dst is in rrCodeformat and has record for typ, if it does not have will send empty.
+// if dst is not in rrCodeformat, will send entire string
+func findRecord(dst string, typ uint16) string {
+	var record string
+	for _, each := range strings.Split(dst, rrCodeDelimiter) {
+		entry := strings.SplitN(each, rrCodePrefixDelimiter, 2)
+		if len(entry) != 2 || entry[0] == "" {
+			return dst
+		}
+		if entry[0] == dns.TypeToString[typ] {
+			record = entry[1]
+		}
+	}
+	return record
+}
+
+func (p *policyPlugin) resolveByCname(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, dst, name string, class uint16) (int, error) {
+	if r == nil || len(r.Question) <= 0 {
+		return dns.RcodeServerFailure, errInvalidDNSMessage
+	}
+
+	dst = dns.Fqdn(dst)
+	rr := &dns.CNAME{
+		Hdr: dns.RR_Header{
+			Name:   name,
+			Rrtype: dns.TypeCNAME,
+			Class:  class,
+		},
+		Target: dst,
+	}
+
+	origName := name
+	r.Question[0].Name = dst
+
+	nw := nonwriter.New(w)
+
+	if _, err := plugin.NextOrFailure(p.Name(), p.next, ctx, nw, r); err != nil {
+		r.Question[0].Name = origName
+		return dns.RcodeServerFailure, err
+	}
+
+	nw.Msg.CopyTo(r)
+	r.Question[0].Name = origName
+
+	r.Answer = append([]dns.RR{rr}, r.Answer...)
+	r.Authoritative = true
+	return r.Rcode, nil
 }


### PR DESCRIPTION
 - New format for redirect data to accommodate support for records of specific type
 - New format like - "rrCode1=record1;rrCode2=record2;rrCode3=record3" , where rrCodeX = A/AAAA/CNAME/TXT"

Example - "A=127.0.0.1;AAAA=23ef:3546::8732;TXT=Ghguyw7g7yiug7;CNAME=google.com"