### PR TITLE
fix aggregation type `append`

### DIFF
--- a/pdp/content.go
+++ b/pdp/content.go
@@ -905,10 +905,10 @@ func (a *aggregator) aggregate(v AttributeValue, err error) (AttributeValue, boo
 		}
 		return MakeListOfStringsValue(a.al), false, nil
 	} else if _, ok := err.(*MissingValueError); ok {
-		if a.a == AggTypeReturnFirst {
+		if a.a == AggTypeReturnFirst || a.al == nil {
 			return UndefinedValue, false, err
 		}
-		return MakeListOfStringsValue(a.al), false, err
+		return MakeListOfStringsValue(a.al), false, nil
 	}
 	return UndefinedValue, true, err
 }

--- a/pdp/content_test.go
+++ b/pdp/content_test.go
@@ -1276,6 +1276,9 @@ func TestLocalContentStorageGetAggregated(t *testing.T) {
 					t.Errorf("case %q: expected error %q but got (%T) %q", tc.name, tc.err, err, err)
 				}
 			} else {
+				if err != nil {
+					t.Errorf("case %q: expected no error but got (%T) %q", tc.name, err, err)
+				}
 				s, err := v.Serialize()
 				if err != nil {
 					t.Errorf("case %q: failed to serialize result with error %q", tc.name, err)


### PR DESCRIPTION
- if aggregation type is "append" (or "append unique") and the last key in the
  list is unknown then the MissingValue error was unexpectedly returned even if
  some data was already collected for the previous paths. Now it returns data
  with no error in this case.
- fixed unit test logic to check actual error when no error expected