### PR TITLE
skip benchmarks in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Build & Test
-      run: make
+      run: make build test
     - name: Coverage
       run: bash <(curl -s https://codecov.io/bash)
   lint:


### PR DESCRIPTION
No need to burn CPU on benchmarks for every CI run.